### PR TITLE
Add Git HTTP mock server coverage for push tests

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -26,8 +26,17 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@v6
 
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: "npm"
+
       - name: Install dependencies
         run: uv sync --frozen --all-groups
+
+      - name: Install Node dependencies
+        run: npm ci
 
       - name: Lint
         run: uv run ruff check .

--- a/.gitignore
+++ b/.gitignore
@@ -217,3 +217,6 @@ __marimo__/
 
 # ai
 .codex
+
+# Node
+node_modules/

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ help: ## this help
 #########
 install: ## install requirements
 	uv sync --all-groups
+	npm install
 
 install-pre-commit: ## install the git pre-commit hook
 	uv run pre-commit install
@@ -29,6 +30,9 @@ typecheck: ## run mypy
 
 test: ## run tests
 	uv run pytest --subprocess-vcr=record
+
+test-git-http: ## run git HTTP integration tests
+	uv run pytest -m git_http_integration
 
 check: ## run local CI checks
 	uv run pre-commit run --all-files

--- a/README.md
+++ b/README.md
@@ -22,6 +22,16 @@ Figuring out agentic workflows with a Turing Pi cluster.
 ### Commands
 
 ```bash
+# install Python and Node test dependencies
+uv sync --all-groups
+npm install
+
+# run tests
+uv run pytest --subprocess-vcr=record
+
+# run only Git HTTP integration tests
+uv run pytest -m git_http_integration
+
 # create key for workers
 ssh-keygen -t ed25519
 
@@ -41,3 +51,8 @@ uv tool install ansible-core --with ansible
 # create Fine Grained Personal Access Token with ability to create PR
 # https://github.com/settings/personal-access-tokens/
 ```
+
+## Testing
+
+Git HTTP integration tests use `git-http-mock-server`, which shells out to the system `git`
+installation. Run `npm install` before executing `uv run pytest -m git_http_integration`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,655 @@
+{
+  "name": "devops-agent",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "devops-agent",
+      "devDependencies": {
+        "git-http-mock-server": "2.0.0"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/apache-crypt": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/apache-crypt/-/apache-crypt-1.2.6.tgz",
+      "integrity": "sha512-072WetlM4blL8PREJVeY+WHiUh1R5VNt2HfceGS8aKqttPHcmqE5pkKuXPz/ULmJOFkc8Hw3kfKl6vy7Qka6DA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "unix-crypt-td-js": "^1.1.4"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/apache-md5": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/apache-md5/-/apache-md5-1.1.8.tgz",
+      "integrity": "sha512-FCAJojipPn0bXjuEpjOOOMN8FZDkxfWWp4JGN9mifU2IhxvKyXZYqpzPHdnTSUpmPDy+tsslB6Z1g+Vg6nVbYA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/array-union": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+      "integrity": "sha512-Dxr6QJj/RdU/hCaBjOfxW+q6lyuVE6JFWIrAUpuOOhoJJoQ99cUn3igRaHVB5P9WrgFVN0FfArM3x0cueOU8ng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-uniq": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/array-uniq": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "integrity": "sha512-MNha4BWQ6JbwhFhj03YK552f7cb3AzoE8SzeljgChvL1dl3IcvggXVz1DilzySZkCja+CXuZbdW7yATchWn8/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/asn1": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/bcryptjs": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+      "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/crypto-random-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
+      "integrity": "sha512-GsVpkFPlycH7/fRR7Dhcmnoii54gV1nz7y4CWyeFS14N+JVBBhY+r8amRHE4BwSYal7BPTDp8isvAlCxyFt3Hg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/daemonize-process": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/daemonize-process/-/daemonize-process-1.0.9.tgz",
+      "integrity": "sha512-YoB+AmcgHIBDVeyfVWSCV90FNk799zX8Uvn7RJTDCD8Y0EMNbSfIKLG961VgchJme2GHmqpXUuV8Rxe2j2L+bw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/dir-glob": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.2.2.tgz",
+      "integrity": "sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-type": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/fixturez": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fixturez/-/fixturez-1.1.0.tgz",
+      "integrity": "sha512-c4q9eZsAmCzj9gkrEO/YwIRlrHWt/TXQiX9jR9WeLFOqeeV6EyzdiiV28CpSzF6Ip+gyYrSv5UeOHqyzfcNTVA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fs-extra": "^5.0.0",
+        "globby": "^7.1.1",
+        "signal-exit": "^3.0.2",
+        "tempy": "^0.2.1"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
+      "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/git-http-mock-server": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/git-http-mock-server/-/git-http-mock-server-2.0.0.tgz",
+      "integrity": "sha512-LOCls7jjuzwfKmUbcFsqj2yIEqExBzv0rA1tL7j1ULhRLAax4U1Bd/rbU9ebtri1ldzgcPD1VAyuhS1pvDC2pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "basic-auth": "^2.0.0",
+        "buffer-equal-constant-time": "^1.0.1",
+        "chalk": "^2.4.1",
+        "daemonize-process": "^1.0.9",
+        "fixturez": "^1.1.0",
+        "htpasswd-js": "^1.0.2",
+        "micro-cors": "^0.1.1",
+        "minimisted": "^2.0.0",
+        "ssh-keygen": "^0.4.2",
+        "ssh2": "^0.6.1",
+        "tree-kill": "^1.2.0"
+      },
+      "bin": {
+        "git-http-mock-server": "http-daemon.js",
+        "git-ssh-mock-server": "ssh-daemon.js"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/globby": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-7.1.1.tgz",
+      "integrity": "sha512-yANWAN2DUcBtuus5Cpd+SKROzXHs2iVXFZt/Ykrfz6SAXqacLX25NZpltE+39ceMexYF4TtEadjuSTw8+3wX4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-union": "^1.0.1",
+        "dir-glob": "^2.0.0",
+        "glob": "^7.1.2",
+        "ignore": "^3.3.5",
+        "pify": "^3.0.0",
+        "slash": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/htpasswd-js": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/htpasswd-js/-/htpasswd-js-1.0.2.tgz",
+      "integrity": "sha512-KON5L4YKYXk647tmVclKgmHHG5nApjy9K+WiRoScnoWhS63lMoTca1ommUW2XQ3FDW8TtNDIQA7J0WYXICbMAA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "apache-crypt": "^1.2.1",
+        "apache-md5": "^1.1.2",
+        "bcryptjs": "^2.4.3",
+        "fs-extra": "^4.0.2",
+        "xerror": "^1.1.2"
+      }
+    },
+    "node_modules/htpasswd-js/node_modules/fs-extra": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
+      "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "3.3.10",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
+      "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/micro-cors": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/micro-cors/-/micro-cors-0.1.1.tgz",
+      "integrity": "sha512-6WqIahA5sbQR1Gjexp1VuWGFDKbZZleJb/gy1khNGk18a6iN1FdTcr3Q8twaxkV5H94RjxIBjirYbWCehpMBFw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minimisted": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/minimisted/-/minimisted-2.0.1.tgz",
+      "integrity": "sha512-1oPjfuLQa2caorJUM8HV8lGgWCc0qqAO1MNv/k05G4qslmsndV/5WdNZrqCiyqiz3wohia2Ij2B7w2Dr7/IyrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-type": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+      "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pify": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/slash": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+      "integrity": "sha512-3TYDR7xWt4dIqV2JauJr+EJeW356RXijHeUlO+8djJ+uBXPn8/2dpzBc8yQhh583sVvc9CvFAeQVgijsH+PNNg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ssh-keygen": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/ssh-keygen/-/ssh-keygen-0.4.2.tgz",
+      "integrity": "sha512-SlEWW3cCtz87jwtCTfxo+tR+SQd4jJXWaBI/D9JVd74b2/N9ZvrWcd9lMFwFv0iMYb4aVAeMderH4AK5ZyW+Nw==",
+      "dev": true,
+      "dependencies": {
+        "underscore": "1.4.x"
+      },
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/ssh2": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-0.6.2.tgz",
+      "integrity": "sha512-DJ+dOhXEEsmNpcQTI0x69FS++JH6qqL/ltEHf01pI1SSLMAcmD+hL4jRwvHjPwynPsmSUbHJ/WIZYzROfqZWjA==",
+      "dev": true,
+      "dependencies": {
+        "ssh2-streams": "~0.2.0"
+      },
+      "engines": {
+        "node": ">=4.5.0"
+      }
+    },
+    "node_modules/ssh2-streams": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/ssh2-streams/-/ssh2-streams-0.2.1.tgz",
+      "integrity": "sha512-3zCOsmunh1JWgPshfhKmBCL3lUtHPoh+a/cyQ49Ft0Q0aF7xgN06b76L+oKtFi0fgO57FLjFztb1GlJcEZ4a3Q==",
+      "dev": true,
+      "dependencies": {
+        "asn1": "~0.2.0",
+        "semver": "^5.1.0",
+        "streamsearch": "~0.1.2"
+      },
+      "engines": {
+        "node": ">=4.5.0"
+      }
+    },
+    "node_modules/streamsearch": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
+      "integrity": "sha512-jos8u++JKm0ARcSUTAZXOVC0mSox7Bhn6sBgty73P1f3JGf7yG2clTbBNHUdde/kdvP2FESam+vM6l8jBrNxHA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/temp-dir": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-1.0.0.tgz",
+      "integrity": "sha512-xZFXEGbG7SNC3itwBzI3RYjq/cEhBkx2hJuKGIUOcEULmkQExXiHat2z/qkISYsuR+IKumhEfKKbV5qXmhICFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/tempy": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/tempy/-/tempy-0.2.1.tgz",
+      "integrity": "sha512-LB83o9bfZGrntdqPuRdanIVCPReam9SOZKW0fOy5I9X3A854GGWi0tjCqoXEk84XIEYBc/x9Hq3EFop/H5wJaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "temp-dir": "^1.0.0",
+        "unique-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
+    "node_modules/underscore": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
+      "integrity": "sha512-ZqGrAgaqqZM7LGRzNjLnw5elevWb5M8LEoDMadxIW3OWbcv72wMMgKdwOKpd5Fqxe8choLD8HN3iSj3TUh/giQ==",
+      "dev": true
+    },
+    "node_modules/unique-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
+      "integrity": "sha512-ODgiYu03y5g76A1I9Gt0/chLCzQjvzDy7DsZGsLOE/1MrF6wriEskSncj1+/C58Xk/kPZDppSctDybCwOSaGAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "crypto-random-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/unix-crypt-td-js": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/unix-crypt-td-js/-/unix-crypt-td-js-1.1.4.tgz",
+      "integrity": "sha512-8rMeVYWSIyccIJscb9NdCfZKSRBKYTeVnwmiRYT2ulE3qd1RaDQ0xQDP+rI3ccIWbhu/zuo5cgN8z73belNZgw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/xerror": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/xerror/-/xerror-1.1.3.tgz",
+      "integrity": "sha512-2l5hmDymDUIuKT53v/nYxofTMUDQuu5P/Y3qHOjQiih6QUHBCgWpbpL3I8BoE5TVfUVTMmUQ0jdUAimTGc9UIg==",
+      "dev": true,
+      "license": "Apache-2.0"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "devops-agent",
+  "private": true,
+  "devDependencies": {
+    "git-http-mock-server": "2.0.0"
+  },
+  "scripts": {
+    "git-http-mock-server": "git-http-mock-server"
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dev = [
 pythonpath = ["."]
 addopts = "--subprocess-vcr=replay"
 markers = [
+    "git_http_integration: tests that require the git-http-mock-server Node dependency",
     "subprocess_vcr: record and replay subprocess output",
 ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,171 @@
+import os
+import shutil
+import socket
+import subprocess
+import time
+from collections.abc import Iterator
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _run_git(args: list[str], cwd: Path) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        check=True,
+        cwd=cwd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def _find_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _wait_for_remote(url: str, timeout_seconds: float = 10.0) -> None:
+    deadline = time.monotonic() + timeout_seconds
+    last_error: subprocess.CalledProcessError | None = None
+
+    while time.monotonic() < deadline:
+        try:
+            subprocess.run(
+                ["git", "ls-remote", url],
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            return
+        except subprocess.CalledProcessError as exc:
+            last_error = exc
+            time.sleep(0.1)
+
+    if last_error is None:
+        raise RuntimeError(f"Timed out waiting for git remote {url}")
+
+    error_output = last_error.stderr.strip() or last_error.stdout.strip()
+    raise RuntimeError(f"Timed out waiting for git remote {url}: {error_output}")
+
+
+@dataclass(frozen=True)
+class GitHttpMockServer:
+    root: Path
+    port: int
+
+    @property
+    def base_url(self) -> str:
+        return f"http://127.0.0.1:{self.port}"
+
+    def repo_url(self, repo_name: str) -> str:
+        return f"{self.base_url}/{repo_name}.git"
+
+    def create_bare_repo(self, repo_name: str) -> Path:
+        repo_path = self.root / f"{repo_name}.git"
+        subprocess.run(
+            ["git", "init", "--bare", repo_path.name],
+            check=True,
+            cwd=self.root,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        subprocess.run(
+            ["git", "config", "http.receivepack", "true"],
+            check=True,
+            cwd=repo_path,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        return repo_path
+
+    def install_post_receive_hook(self, repo_name: str, log_path: Path) -> None:
+        hook_path = self.root / f"{repo_name}.git" / "hooks" / "post-receive"
+        hook_path.write_text(
+            "#!/bin/sh\n"
+            f"cat >> {log_path}\n",
+            encoding="utf-8",
+        )
+        hook_path.chmod(0o755)
+
+
+@pytest.fixture
+def git_http_mock_server(tmp_path: Path) -> Iterator[GitHttpMockServer]:
+    node_binary = shutil.which("node")
+    if node_binary is None:
+        pytest.skip("node is required for git_http_integration tests")
+
+    server_binary = REPO_ROOT / "node_modules" / ".bin" / "git-http-mock-server"
+    if not server_binary.exists():
+        pytest.skip("npm install must be run before git_http_integration tests")
+
+    server_root = tmp_path / "git-http-remotes"
+    server_root.mkdir()
+    port = _find_free_port()
+    env = os.environ.copy()
+    env.update(
+        {
+            "GIT_HTTP_MOCK_SERVER_PORT": str(port),
+            "GIT_HTTP_MOCK_SERVER_ROOT": str(server_root),
+        }
+    )
+
+    process = subprocess.Popen(
+        [str(server_binary)],
+        cwd=server_root,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    server = GitHttpMockServer(root=server_root, port=port)
+
+    try:
+        seed_repo = server.create_bare_repo("healthcheck")
+        _wait_for_remote(server.repo_url(seed_repo.stem.removesuffix(".git")))
+        yield server
+    finally:
+        process.terminate()
+        try:
+            process.communicate(timeout=5)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.communicate()
+
+
+@pytest.fixture
+def git_working_repo_with_remote(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    git_http_mock_server: GitHttpMockServer,
+) -> Path:
+    repo_path = tmp_path / "working-repo"
+    repo_path.mkdir()
+    monkeypatch.chdir(repo_path)
+
+    _run_git(["init"], cwd=repo_path)
+    _run_git(["config", "user.name", "DevOps Agent Tests"], cwd=repo_path)
+    _run_git(["config", "user.email", "devops-agent-tests@example.com"], cwd=repo_path)
+
+    tracked_file = repo_path / "README.md"
+    tracked_file.write_text("# Temp Repo\n", encoding="utf-8")
+    _run_git(["add", "README.md"], cwd=repo_path)
+    _run_git(["commit", "-m", "Initial commit"], cwd=repo_path)
+
+    remote_name = "origin"
+    remote_repo_name = "origin"
+    git_http_mock_server.create_bare_repo(remote_repo_name)
+    _run_git(
+        ["remote", "add", remote_name, git_http_mock_server.repo_url(remote_repo_name)],
+        cwd=repo_path,
+    )
+
+    return repo_path

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import socket
 import subprocess
 import time
 from collections.abc import Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -55,6 +56,16 @@ def _wait_for_remote(url: str, timeout_seconds: float = 10.0) -> None:
     raise RuntimeError(f"Timed out waiting for git remote {url}: {error_output}")
 
 
+@contextmanager
+def _chdir(path: Path) -> Iterator[None]:
+    current_dir = Path.cwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(current_dir)
+
+
 @dataclass(frozen=True)
 class GitHttpMockServer:
     root: Path
@@ -90,8 +101,7 @@ class GitHttpMockServer:
     def install_post_receive_hook(self, repo_name: str, log_path: Path) -> None:
         hook_path = self.root / f"{repo_name}.git" / "hooks" / "post-receive"
         hook_path.write_text(
-            "#!/bin/sh\n"
-            f"cat >> {log_path}\n",
+            f"#!/bin/sh\ncat >> {log_path}\n",
             encoding="utf-8",
         )
         hook_path.chmod(0o755)
@@ -144,28 +154,27 @@ def git_http_mock_server(tmp_path: Path) -> Iterator[GitHttpMockServer]:
 @pytest.fixture
 def git_working_repo_with_remote(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
     git_http_mock_server: GitHttpMockServer,
 ) -> Path:
     repo_path = tmp_path / "working-repo"
     repo_path.mkdir()
-    monkeypatch.chdir(repo_path)
 
-    _run_git(["init"], cwd=repo_path)
-    _run_git(["config", "user.name", "DevOps Agent Tests"], cwd=repo_path)
-    _run_git(["config", "user.email", "devops-agent-tests@example.com"], cwd=repo_path)
+    with _chdir(repo_path):
+        _run_git(["init"], cwd=repo_path)
+        _run_git(["config", "user.name", "DevOps Agent Tests"], cwd=repo_path)
+        _run_git(["config", "user.email", "devops-agent-tests@example.com"], cwd=repo_path)
 
-    tracked_file = repo_path / "README.md"
-    tracked_file.write_text("# Temp Repo\n", encoding="utf-8")
-    _run_git(["add", "README.md"], cwd=repo_path)
-    _run_git(["commit", "-m", "Initial commit"], cwd=repo_path)
+        tracked_file = repo_path / "README.md"
+        tracked_file.write_text("# Temp Repo\n", encoding="utf-8")
+        _run_git(["add", "README.md"], cwd=repo_path)
+        _run_git(["commit", "-m", "Initial commit"], cwd=repo_path)
 
-    remote_name = "origin"
-    remote_repo_name = "origin"
-    git_http_mock_server.create_bare_repo(remote_repo_name)
-    _run_git(
-        ["remote", "add", remote_name, git_http_mock_server.repo_url(remote_repo_name)],
-        cwd=repo_path,
-    )
+        remote_name = "origin"
+        remote_repo_name = "origin"
+        git_http_mock_server.create_bare_repo(remote_repo_name)
+        _run_git(
+            ["remote", "add", remote_name, git_http_mock_server.repo_url(remote_repo_name)],
+            cwd=repo_path,
+        )
 
     return repo_path

--- a/tests/tools/test_git.py
+++ b/tests/tools/test_git.py
@@ -1,7 +1,6 @@
 import subprocess
 from pathlib import Path
-from typing import Any
-from unittest.mock import Mock, call, patch
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -91,65 +90,11 @@ class TestCreateGitCommit:
 
 
 class TestGitPush:
-    @patch("agent.tools.git.subprocess.run")
-    def test_git_push_uses_current_branch_when_branch_not_provided(self, mock_run: Mock):
-        mock_run.side_effect = [
-            Mock(stdout="main\n", stderr=""),
-            Mock(stdout="", stderr=""),
-        ]
-
-        result = git_push()
-
-        assert result == "Pushed main to origin"
-        assert mock_run.call_args_list == [
-            call(
-                ["git", "rev-parse", "--abbrev-ref", "HEAD"],
-                check=True,
-                stdout=-1,
-                stderr=-1,
-                text=True,
-            ),
-            call(
-                ["git", "push", "origin", "main"],
-                check=True,
-                stdout=-1,
-                stderr=-1,
-                text=True,
-            ),
-        ]
-
-    @patch("agent.tools.git.subprocess.run")
-    def test_git_push_uses_explicit_remote_and_branch(self, mock_run: Mock):
-        mock_run.return_value = Mock(stdout="", stderr="")
-
-        result = git_push(remote="upstream", branch="feature/test")
-
-        assert result == "Pushed feature/test to upstream"
-        mock_run.assert_called_once_with(
-            ["git", "push", "upstream", "feature/test"],
-            check=True,
-            stdout=-1,
-            stderr=-1,
-            text=True,
-        )
-
-    @pytest.mark.parametrize("remote", ["", "   "])
-    def test_git_push_rejects_empty_remote(self, remote: str):
-        with pytest.raises(ValueError):
-            git_push(remote=remote)
-
-    @pytest.mark.parametrize("branch", ["", "   "])
-    def test_git_push_rejects_empty_branch(self, branch: str):
-        with pytest.raises(ValueError):
-            git_push(branch=branch)
-
-
-@pytest.mark.git_http_integration
-class TestGitPushIntegration:
-    def test_git_push_pushes_current_branch_to_http_remote(
+    @pytest.mark.git_http_integration
+    def test_git_push_uses_current_branch_when_branch_not_provided(
         self,
         git_working_repo_with_remote: Path,
-        git_http_mock_server: Any,
+        git_http_mock_server,
     ):
         _ = git_working_repo_with_remote
         received_refs_log = git_http_mock_server.root / "origin-received-refs.log"
@@ -174,16 +119,16 @@ class TestGitPushIntegration:
         )
 
         result = git_push()
-
         received_refs = received_refs_log.read_text(encoding="utf-8").strip()
 
         assert result == "Pushed feature/http-push to origin"
         assert received_refs.endswith("refs/heads/feature/http-push")
 
-    def test_git_push_pushes_explicit_branch_to_http_remote(
+    @pytest.mark.git_http_integration
+    def test_git_push_uses_explicit_remote_and_branch(
         self,
         git_working_repo_with_remote: Path,
-        git_http_mock_server: Any,
+        git_http_mock_server,
     ):
         _ = git_working_repo_with_remote
         received_refs_log = git_http_mock_server.root / "origin-explicit-received-refs.log"
@@ -214,17 +159,17 @@ class TestGitPushIntegration:
         )
 
         result = git_push(remote="origin", branch="feature/explicit-http")
-
         received_refs = received_refs_log.read_text(encoding="utf-8").strip()
 
         assert result == "Pushed feature/explicit-http to origin"
         assert received_refs.endswith("refs/heads/feature/explicit-http")
 
+    @pytest.mark.git_http_integration
     def test_git_push_surfaces_missing_remote_repo_failure(
         self,
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
-        git_http_mock_server: Any,
+        git_http_mock_server,
     ):
         repo_path = tmp_path / "working-repo"
         repo_path.mkdir()
@@ -283,6 +228,16 @@ class TestGitPushIntegration:
 
         with pytest.raises(RuntimeError, match="not found|repository|404"):
             git_push()
+
+    @pytest.mark.parametrize("remote", ["", "   "])
+    def test_git_push_rejects_empty_remote(self, remote: str):
+        with pytest.raises(ValueError):
+            git_push(remote=remote)
+
+    @pytest.mark.parametrize("branch", ["", "   "])
+    def test_git_push_rejects_empty_branch(self, branch: str):
+        with pytest.raises(ValueError):
+            git_push(branch=branch)
 
 
 class TestCreateGitBranch:

--- a/tests/tools/test_git.py
+++ b/tests/tools/test_git.py
@@ -1,5 +1,6 @@
 import subprocess
 from pathlib import Path
+from typing import Any
 from unittest.mock import Mock, call, patch
 
 import pytest
@@ -141,6 +142,147 @@ class TestGitPush:
     def test_git_push_rejects_empty_branch(self, branch: str):
         with pytest.raises(ValueError):
             git_push(branch=branch)
+
+
+@pytest.mark.git_http_integration
+class TestGitPushIntegration:
+    def test_git_push_pushes_current_branch_to_http_remote(
+        self,
+        git_working_repo_with_remote: Path,
+        git_http_mock_server: Any,
+    ):
+        _ = git_working_repo_with_remote
+        received_refs_log = git_http_mock_server.root / "origin-received-refs.log"
+        git_http_mock_server.install_post_receive_hook("origin", received_refs_log)
+
+        subprocess.run(
+            ["git", "checkout", "-b", "feature/http-push"],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        (git_working_repo_with_remote / "README.md").write_text(
+            "# Temp Repo\nupdated via http\n", encoding="utf-8"
+        )
+        subprocess.run(
+            ["git", "commit", "-am", "Push over HTTP"],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+
+        result = git_push()
+
+        received_refs = received_refs_log.read_text(encoding="utf-8").strip()
+
+        assert result == "Pushed feature/http-push to origin"
+        assert received_refs.endswith("refs/heads/feature/http-push")
+
+    def test_git_push_pushes_explicit_branch_to_http_remote(
+        self,
+        git_working_repo_with_remote: Path,
+        git_http_mock_server: Any,
+    ):
+        _ = git_working_repo_with_remote
+        received_refs_log = git_http_mock_server.root / "origin-explicit-received-refs.log"
+        git_http_mock_server.install_post_receive_hook("origin", received_refs_log)
+
+        subprocess.run(
+            ["git", "checkout", "-b", "feature/explicit-http"],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        new_file = git_working_repo_with_remote / "playbook.yml"
+        new_file.write_text("---\n- hosts: all\n", encoding="utf-8")
+        subprocess.run(
+            ["git", "add", "playbook.yml"],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "Explicit branch push"],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+
+        result = git_push(remote="origin", branch="feature/explicit-http")
+
+        received_refs = received_refs_log.read_text(encoding="utf-8").strip()
+
+        assert result == "Pushed feature/explicit-http to origin"
+        assert received_refs.endswith("refs/heads/feature/explicit-http")
+
+    def test_git_push_surfaces_missing_remote_repo_failure(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        git_http_mock_server: Any,
+    ):
+        repo_path = tmp_path / "working-repo"
+        repo_path.mkdir()
+        monkeypatch.chdir(repo_path)
+
+        subprocess.run(
+            ["git", "init"],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "DevOps Agent Tests"],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.email", "devops-agent-tests@example.com"],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        (repo_path / "README.md").write_text("# Temp Repo\n", encoding="utf-8")
+        subprocess.run(
+            ["git", "add", "README.md"],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "Initial commit"],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        subprocess.run(
+            ["git", "checkout", "-b", "feature/missing-http"],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        subprocess.run(
+            ["git", "remote", "add", "origin", git_http_mock_server.repo_url("missing-remote")],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+
+        with pytest.raises(RuntimeError, match="not found|repository|404"):
+            git_push()
 
 
 class TestCreateGitBranch:

--- a/tests/tools/test_git.py
+++ b/tests/tools/test_git.py
@@ -1,4 +1,7 @@
+import os
 import subprocess
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
 from unittest.mock import Mock, patch
 
@@ -13,38 +16,48 @@ from agent.tools import (
 )
 
 
+@contextmanager
+def _chdir(path: Path) -> Iterator[None]:
+    current_dir = Path.cwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(current_dir)
+
+
 @pytest.fixture
-def git_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+def git_repo(tmp_path: Path) -> Path:
     repo_path = tmp_path / "repo"
     repo_path.mkdir()
-    monkeypatch.chdir(repo_path)
 
-    subprocess.run(["git", "init"], check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    subprocess.run(
-        ["git", "config", "user.name", "DevOps Agent Tests"],
-        check=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-    )
-    subprocess.run(
-        ["git", "config", "user.email", "devops-agent-tests@example.com"],
-        check=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-    )
+    with _chdir(repo_path):
+        subprocess.run(["git", "init"], check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        subprocess.run(
+            ["git", "config", "user.name", "DevOps Agent Tests"],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        subprocess.run(
+            ["git", "config", "user.email", "devops-agent-tests@example.com"],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
 
-    tracked_file = repo_path / "README.md"
-    tracked_file.write_text("# Temp Repo\n", encoding="utf-8")
-    subprocess.run(
-        ["git", "add", "README.md"], check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
-    )
-    subprocess.run(
-        ["git", "commit", "-m", "Initial commit"],
-        check=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-    )
+        tracked_file = repo_path / "README.md"
+        tracked_file.write_text("# Temp Repo\n", encoding="utf-8")
+        subprocess.run(
+            ["git", "add", "README.md"], check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "Initial commit"],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
 
     return repo_path
 
@@ -96,29 +109,29 @@ class TestGitPush:
         git_working_repo_with_remote: Path,
         git_http_mock_server,
     ):
-        _ = git_working_repo_with_remote
         received_refs_log = git_http_mock_server.root / "origin-received-refs.log"
         git_http_mock_server.install_post_receive_hook("origin", received_refs_log)
 
-        subprocess.run(
-            ["git", "checkout", "-b", "feature/http-push"],
-            check=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-        )
-        (git_working_repo_with_remote / "README.md").write_text(
-            "# Temp Repo\nupdated via http\n", encoding="utf-8"
-        )
-        subprocess.run(
-            ["git", "commit", "-am", "Push over HTTP"],
-            check=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-        )
+        with _chdir(git_working_repo_with_remote):
+            subprocess.run(
+                ["git", "checkout", "-b", "feature/http-push"],
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            (git_working_repo_with_remote / "README.md").write_text(
+                "# Temp Repo\nupdated via http\n", encoding="utf-8"
+            )
+            subprocess.run(
+                ["git", "commit", "-am", "Push over HTTP"],
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
 
-        result = git_push()
+            result = git_push()
         received_refs = received_refs_log.read_text(encoding="utf-8").strip()
 
         assert result == "Pushed feature/http-push to origin"
@@ -130,35 +143,35 @@ class TestGitPush:
         git_working_repo_with_remote: Path,
         git_http_mock_server,
     ):
-        _ = git_working_repo_with_remote
         received_refs_log = git_http_mock_server.root / "origin-explicit-received-refs.log"
         git_http_mock_server.install_post_receive_hook("origin", received_refs_log)
 
-        subprocess.run(
-            ["git", "checkout", "-b", "feature/explicit-http"],
-            check=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-        )
-        new_file = git_working_repo_with_remote / "playbook.yml"
-        new_file.write_text("---\n- hosts: all\n", encoding="utf-8")
-        subprocess.run(
-            ["git", "add", "playbook.yml"],
-            check=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-        )
-        subprocess.run(
-            ["git", "commit", "-m", "Explicit branch push"],
-            check=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-        )
+        with _chdir(git_working_repo_with_remote):
+            subprocess.run(
+                ["git", "checkout", "-b", "feature/explicit-http"],
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            new_file = git_working_repo_with_remote / "playbook.yml"
+            new_file.write_text("---\n- hosts: all\n", encoding="utf-8")
+            subprocess.run(
+                ["git", "add", "playbook.yml"],
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            subprocess.run(
+                ["git", "commit", "-m", "Explicit branch push"],
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
 
-        result = git_push(remote="origin", branch="feature/explicit-http")
+            result = git_push(remote="origin", branch="feature/explicit-http")
         received_refs = received_refs_log.read_text(encoding="utf-8").strip()
 
         assert result == "Pushed feature/explicit-http to origin"
@@ -168,66 +181,65 @@ class TestGitPush:
     def test_git_push_surfaces_missing_remote_repo_failure(
         self,
         tmp_path: Path,
-        monkeypatch: pytest.MonkeyPatch,
         git_http_mock_server,
     ):
         repo_path = tmp_path / "working-repo"
         repo_path.mkdir()
-        monkeypatch.chdir(repo_path)
 
-        subprocess.run(
-            ["git", "init"],
-            check=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-        )
-        subprocess.run(
-            ["git", "config", "user.name", "DevOps Agent Tests"],
-            check=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-        )
-        subprocess.run(
-            ["git", "config", "user.email", "devops-agent-tests@example.com"],
-            check=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-        )
-        (repo_path / "README.md").write_text("# Temp Repo\n", encoding="utf-8")
-        subprocess.run(
-            ["git", "add", "README.md"],
-            check=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-        )
-        subprocess.run(
-            ["git", "commit", "-m", "Initial commit"],
-            check=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-        )
-        subprocess.run(
-            ["git", "checkout", "-b", "feature/missing-http"],
-            check=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-        )
-        subprocess.run(
-            ["git", "remote", "add", "origin", git_http_mock_server.repo_url("missing-remote")],
-            check=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-        )
+        with _chdir(repo_path):
+            subprocess.run(
+                ["git", "init"],
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            subprocess.run(
+                ["git", "config", "user.name", "DevOps Agent Tests"],
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            subprocess.run(
+                ["git", "config", "user.email", "devops-agent-tests@example.com"],
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            (repo_path / "README.md").write_text("# Temp Repo\n", encoding="utf-8")
+            subprocess.run(
+                ["git", "add", "README.md"],
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            subprocess.run(
+                ["git", "commit", "-m", "Initial commit"],
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            subprocess.run(
+                ["git", "checkout", "-b", "feature/missing-http"],
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            subprocess.run(
+                ["git", "remote", "add", "origin", git_http_mock_server.repo_url("missing-remote")],
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
 
-        with pytest.raises(RuntimeError, match="not found|repository|404"):
-            git_push()
+            with pytest.raises(RuntimeError, match="not found|repository|404"):
+                git_push()
 
     @pytest.mark.parametrize("remote", ["", "   "])
     def test_git_push_rejects_empty_remote(self, remote: str):


### PR DESCRIPTION
## Summary

Add `git-http-mock-server` as a narrow test dependency so Git remote behavior is exercised against a real HTTP remote instead of only subprocess mocks.
This adds a reusable pytest fixture layer, updates CI and local test commands for the Node dependency, and uses the HTTP-backed harness directly in the `git_push()` tests.

## Changes

- Added `package.json` and `package-lock.json` with pinned `git-http-mock-server` test dependencies.
- Added HTTP mock server fixtures in `tests/conftest.py` and a `git_http_integration` pytest marker.
- Reworked `git_push()` remote coverage in `tests/tools/test_git.py` to use real HTTP-backed tests in the existing test class.
- Updated CI, `Makefile`, `README.md`, and `.gitignore` for the new test workflow.

## Validation

- [ ] `uv run pre-commit run --all-files`
- [x] `uv run mypy`
- [x] `uv run pytest --subprocess-vcr=record`

## Infra Notes

- Deployment, rollout, or operator follow-up: Run `npm install` before HTTP integration tests locally.
- Secrets, credentials, or permissions touched: None.
- Ansible, CI, or agent behavior impact: CI now installs Node dependencies before running tests.

## Risks

- Known tradeoffs: The test suite now has a small Node-based dependency for Git HTTP integration coverage.
- Follow-up work: If needed, extend the same harness to cover additional remote Git operations beyond `git_push()`.
