### PR TITLE
Document remote tooling workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,36 @@
+# Agent Notes
+
+## Workflow
+
+- Rename the branch early with a name that matches the work. Use concrete wording such as `document-tooling-notes`, not generic names like `updates` or `fixes`.
+- Keep branch names short and task-specific.
+- When opening a PR, fill out `.github/pull_request_template.md` completely. Do not leave the summary, validation, infra notes, or risks sections as placeholders.
+
+## Tools And Remote Boundaries
+
+- Treat anything that reaches outside the local workspace as remote work. That includes Git pushes, PR creation, SSH access, Ansible runs against non-local hosts, cloud APIs, and any hosted service credentials.
+- Prefer local inspection first. Read code, inventory, config, playbooks, and tests before running a remote action.
+- Document the remote dependency in the PR description when a change depends on credentials, network access, or external systems.
+- If a tool has both local and remote modes, make the local path the default in development and tests.
+
+## Setup Expectations
+
+- Python tooling is managed with `uv`. Install dependencies with `uv sync --frozen --all-groups`.
+- Git HTTP integration tests also require Node dependencies from `package.json`. Install them with `npm install`.
+- The main validation commands in this repo are:
+  - `uv run pre-commit run --all-files`
+  - `uv run mypy`
+  - `uv run pytest`
+  - `uv run pytest --subprocess-vcr=record`
+  - `uv run pytest -m git_http_integration`
+- Ansible playbooks live under `ansible/playbooks`, and the tool surface exposes a validated playbook registry rather than a plain filename list.
+- The Ansible tool writes temp files under `.ansible/tmp` so runs do not depend on a system temp directory layout.
+
+## Testing Guidance
+
+- Do not make tests depend on a live remote system unless the test is explicitly intended as manual verification.
+- For subprocess-driven integrations, prefer recorded fixtures with `subprocess-vcr` so tests remain deterministic.
+- Pytest defaults to replay mode through `addopts`, so use `--subprocess-vcr=record` only when intentionally updating fixtures.
+- Use the `git_http_integration` marker for Git flows that need a realistic remote without hitting an external host.
+- Keep unit tests focused on command construction, argument validation, and error handling for remote-capable tools.
+- If a remote workflow cannot be covered in automated tests, add a short manual verification note to the PR description.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Figuring out agentic workflows with a Turing Pi cluster.
 
+See `AGENTS.md` for repo-specific guidance on remote tooling, testing expectations, branch naming, and PR writeups.
+
 ## Notes
 
 ### Roles


### PR DESCRIPTION
## Summary

Adds repo-level guidance for how agents should handle remote-capable tools, branch naming, and PR writeups. Also links the new guidance from the README so it is easier to find during normal repo navigation.

## Changes

- Added `AGENTS.md` with workflow notes for naming branches after the task, documenting remote dependencies, and fully completing the PR template.
- Documented setup and testing expectations for `uv`, Node-backed Git HTTP integration tests, pytest VCR replay behavior, and the Ansible playbook registry/tooling surface.
- Linked the repo notes from `README.md`.

## Validation

- [ ] `uv run pre-commit run --all-files`
- [ ] `uv run mypy`
- [ ] `uv run pytest --subprocess-vcr=record`

## Infra Notes

- Deployment, rollout, or operator follow-up: None.
- Secrets, credentials, or permissions touched: None.
- Ansible, CI, or agent behavior impact: Documentation only; no runtime or CI behavior changed.

## Risks

- Known tradeoffs: The guidance will need occasional updates as tooling and workflows evolve.
- Follow-up work: Consider expanding the notes if additional remote-capable tools are added.
