### PR TITLE
Add Conductor workspace setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,3 +111,12 @@ pattern, and `make test` records those fixtures while pytest replays them by def
 
 Git HTTP integration tests use `git-http-mock-server`, which shells out to the system `git`
 installation. Run `npm install` before executing `make test-git-http`.
+
+## Conductor
+
+For Conductor workspaces, `conductor.json` provides a local bootstrap path that runs
+`./scripts/setup-dev.sh`, which delegates to `make install` so both Python and Node
+test dependencies are installed before validation.
+
+This setup path is intentionally limited to local dependency installation. Token and
+`.env` initialization remain in `scripts/bootstrap.sh` and are not run automatically.

--- a/conductor.json
+++ b/conductor.json
@@ -1,0 +1,7 @@
+{
+  "scripts": {
+    "setup": "./scripts/setup-dev.sh",
+    "run": "make test"
+  },
+  "runScriptMode": "nonconcurrent"
+}

--- a/scripts/setup-dev.sh
+++ b/scripts/setup-dev.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+make install


### PR DESCRIPTION
## Summary

Add Conductor workspace bootstrap support so new workspaces install both Python and Node dependencies before running validation. This prevents the Git HTTP integration tests from being skipped solely because `npm install` was never run in the workspace.

## Changes

- Added `conductor.json` with a `setup` script and `run` command for Conductor workspaces.
- Added `scripts/setup-dev.sh` as a local-only bootstrap wrapper that delegates to `make install`.
- Documented the Conductor setup path in `README.md`, and clarified that token and `.env` initialization stay in `scripts/bootstrap.sh`.

## Validation

- [ ] `uv run pre-commit run --all-files`
- [x] `uv run mypy`
- [ ] `uv run pytest --subprocess-vcr=record`

## Infra Notes

- Deployment, rollout, or operator follow-up: Conductor can now use the workspace `setup` hook to prepare local dependencies before tests.
- Secrets, credentials, or permissions touched: None. Automated setup does not run `.env` or token bootstrap.
- Ansible, CI, or agent behavior impact: No runtime or Ansible behavior changed; this only affects local Conductor workspace setup.

## Risks

- Known tradeoffs: `make install` will run `npm install` during Conductor setup, which adds some setup time even for users not running Git HTTP integration tests.
- Follow-up work: If setup cost becomes an issue, the repo could split optional Node test dependencies from the default install path.
