### PR TITLE
Add run history and time check artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,29 @@ uv run python -m agent.main "create a hello world playbook for local nodes"
 
 The generated review includes the proposed filename, metadata header fields, and the full YAML before asking for approval.
 
+## Run History
+
+CLI runs capture a machine-readable run history by default and append each completed session to `docs/autonomous-devops-run-history.jsonl`.
+
+Run history includes:
+
+- the initial prompt
+- major decisions and operational why text
+- tool usage summaries
+- approval and decline outcomes
+- success and failure summaries
+
+Run history does not include:
+
+- hidden reasoning
+- full raw model transcripts
+- full rendered playbook YAML bodies in the history artifact
+- unredacted values for fields that look like secrets, tokens, passwords, or keys
+
+Disable run history by setting `DEVOPS_AGENT_RUN_HISTORY_ENABLED=false`.
+
+Human-readable talk generation is intentionally deferred. This first pass writes only the JSONL artifact.
+
 ### Commands
 
 ```bash

--- a/agent/config.py
+++ b/agent/config.py
@@ -3,3 +3,4 @@ from .secret_manager import SecretsManager
 secret_manager = SecretsManager(path=".env")
 
 OPENAI_API_KEY = secret_manager.get(str, "OPENAI_API_KEY")
+RUN_HISTORY_ENABLED = secret_manager.get(bool, "DEVOPS_AGENT_RUN_HISTORY_ENABLED", True)

--- a/agent/create_ansible_playbook.py
+++ b/agent/create_ansible_playbook.py
@@ -1,11 +1,13 @@
 import re
 from pathlib import Path
 
+import yaml
 from pydantic import BaseModel
 from strands import tool
 
 from .generate_playbook import GeneratePlaybookAgent
 from .playbook_metadata import GeneratedPlaybookMetadata, PlaybookMetadataAgent
+from .run_history import record_event
 
 PLAYBOOKS_DIR = Path("ansible/playbooks")
 
@@ -45,8 +47,36 @@ class CreateAnsiblePlaybookWorkflow:
         self.metadata_agent = metadata_agent or PlaybookMetadataAgent()
 
     def run(self, query: str) -> CreateAnsiblePlaybookResult:
+        record_event(
+            kind="playbook_generation_started",
+            status="started",
+            what="Started generating a new playbook.",
+            why="The registry did not contain a suitable existing playbook for the request.",
+            details={"query": query},
+        )
         generated_playbook = self.generator.run(query)
+        playbook_summary = summarize_generated_playbook(generated_playbook.yaml)
+        record_event(
+            kind="playbook_yaml_generated",
+            status="completed",
+            what="Generated playbook YAML.",
+            why="Draft the requested automation before reviewing metadata and filename.",
+            details=playbook_summary,
+        )
         generated_metadata = self.metadata_agent.run(yaml=generated_playbook.yaml)
+        record_event(
+            kind="playbook_metadata_generated",
+            status="completed",
+            what="Generated playbook metadata.",
+            why="Summarize the new playbook with registry-friendly fields before any write.",
+            details={
+                "name": generated_metadata.name,
+                "description": generated_metadata.description,
+                "target": generated_metadata.target,
+                "requires_approval": generated_metadata.requires_approval,
+                "tags": generated_metadata.tags,
+            },
+        )
         playbook_path = build_playbook_path(generated_metadata.name)
         rendered_playbook = render_playbook_file(
             yaml=generated_playbook.yaml,
@@ -58,10 +88,27 @@ class CreateAnsiblePlaybookWorkflow:
             metadata=generated_metadata,
             rendered_playbook=rendered_playbook,
         )
+        record_event(
+            kind="playbook_preview_presented",
+            status="completed",
+            what="Presented the generated playbook preview.",
+            why="Show the path, metadata, and YAML before asking for write approval.",
+            details={"path": str(playbook_path), **playbook_summary},
+        )
 
         written = confirm_write(playbook_path)
         if not written:
             print("Playbook not written.")
+            record_event(
+                kind="playbook_write_declined",
+                status="declined",
+                what="Playbook write was declined.",
+                why=(
+                    "The workflow requires explicit confirmation before "
+                    "creating a new playbook file."
+                ),
+                details={"path": str(playbook_path), "approved": False},
+            )
             return CreateAnsiblePlaybookResult(
                 path=playbook_path,
                 metadata=generated_metadata,
@@ -69,8 +116,25 @@ class CreateAnsiblePlaybookWorkflow:
                 written=False,
             )
 
+        record_event(
+            kind="playbook_write_approved",
+            status="approved",
+            what="Playbook write was approved.",
+            why="The generated playbook is ready to be written under ansible/playbooks.",
+            details={"path": str(playbook_path), "approved": True},
+        )
         playbook_path.write_text(rendered_playbook, encoding="utf-8")
         print(f"Wrote playbook to {playbook_path}.")
+        record_event(
+            kind="playbook_written",
+            status="completed",
+            what="Wrote the generated playbook file.",
+            why=(
+                "Persist the approved playbook so it can be validated and "
+                "executed through the registry."
+            ),
+            details={"path": str(playbook_path)},
+        )
         return CreateAnsiblePlaybookResult(
             path=playbook_path,
             metadata=generated_metadata,
@@ -120,3 +184,22 @@ def print_preview(
         print(f"    - {tag}")
     print()
     print(rendered_playbook)
+
+
+def summarize_generated_playbook(yaml_text: str) -> dict[str, str | int | list[str]]:
+    parsed = yaml.safe_load(yaml_text)
+    hosts: list[str] = []
+    task_count = 0
+
+    if isinstance(parsed, list):
+        for play in parsed:
+            if not isinstance(play, dict):
+                continue
+            hosts_value = play.get("hosts")
+            if isinstance(hosts_value, str):
+                hosts.append(hosts_value)
+            tasks = play.get("tasks")
+            if isinstance(tasks, list):
+                task_count += len(tasks)
+
+    return {"hosts": hosts, "task_count": task_count}

--- a/agent/generate_playbook.py
+++ b/agent/generate_playbook.py
@@ -1,6 +1,7 @@
 import yaml
 from pydantic import BaseModel, Field, ValidationError, field_validator
 
+from .run_history import record_event
 from .tools import get_ansible_inventory_groups
 from .utils import build_agent, build_model
 
@@ -49,5 +50,50 @@ class GeneratePlaybookAgent:
         )
 
     def run(self, prompt: str) -> GeneratedPlaybookYaml:
-        generated_playbook = self.agent.structured_output(GeneratedPlaybookYaml, prompt)
+        record_event(
+            kind="structured_playbook_generation_started",
+            status="started",
+            what="Started structured playbook generation.",
+            why="Translate the user request into valid Ansible YAML before any file write.",
+            details={"prompt": prompt},
+        )
+        try:
+            generated_playbook = self.agent.structured_output(GeneratedPlaybookYaml, prompt)
+        except Exception as exc:
+            record_event(
+                kind="structured_playbook_generation_failed",
+                status="failed",
+                what="Structured playbook generation failed.",
+                why="The model did not return valid playbook YAML for this request.",
+                details={"error": str(exc), "exception_type": exc.__class__.__name__},
+            )
+            raise
+
+        summary = summarize_generated_yaml(generated_playbook.yaml)
+        record_event(
+            kind="structured_playbook_generation_completed",
+            status="completed",
+            what="Structured playbook generation completed.",
+            why="The generated YAML passed validation as a non-empty playbook list.",
+            details=summary,
+        )
         return generated_playbook
+
+
+def summarize_generated_yaml(yaml_text: str) -> dict[str, int | list[str]]:
+    parsed = yaml.safe_load(yaml_text)
+    hosts: list[str] = []
+    task_count = 0
+
+    if isinstance(parsed, list):
+        for play in parsed:
+            if not isinstance(play, dict):
+                continue
+            hosts_value = play.get("hosts")
+            if isinstance(hosts_value, str):
+                hosts.append(hosts_value)
+            tasks = play.get("tasks")
+            if isinstance(tasks, list):
+                task_count += len(tasks)
+
+    return {"hosts": hosts, "task_count": task_count}

--- a/agent/main.py
+++ b/agent/main.py
@@ -1,6 +1,16 @@
 import argparse
+import sys
 
 from .orchestrator import OrchestratorAgent
+from .run_history import (
+    RUN_HISTORY_PATH,
+    RunHistory,
+    append_session_jsonl,
+    record_event,
+    reset_active_run_history,
+    run_history_enabled,
+    set_active_run_history,
+)
 
 
 def main() -> int:
@@ -8,8 +18,57 @@ def main() -> int:
     parser.add_argument("prompt", help="Natural-language prompt.")
     args = parser.parse_args()
 
-    print(OrchestratorAgent().run(args.prompt))
+    run_history = RunHistory(prompt=args.prompt) if run_history_enabled() else None
+    token = set_active_run_history(run_history) if run_history is not None else None
+
+    if run_history is not None:
+        record_event(
+            kind="run_started",
+            status="started",
+            what="Started CLI invocation.",
+            why="Capture the initial user request before orchestration begins.",
+            details={"prompt": args.prompt},
+        )
+
+    try:
+        response = OrchestratorAgent().run(args.prompt)
+    except Exception as exc:
+        if run_history is not None:
+            record_event(
+                kind="run_failed",
+                status="failed",
+                what="CLI invocation failed.",
+                why="The orchestrator raised an exception before completing the request.",
+                details={"error": str(exc), "exception_type": exc.__class__.__name__},
+            )
+            run_history.finalize(f"failed: {exc}")
+            _append_run_history(run_history)
+        if token is not None:
+            reset_active_run_history(token)
+        raise
+
+    if run_history is not None:
+        record_event(
+            kind="run_completed",
+            status="completed",
+            what="CLI invocation completed successfully.",
+            why="Persist the final agent response for later review.",
+            details={"response": response},
+        )
+        run_history.finalize(response)
+        _append_run_history(run_history)
+        if token is not None:
+            reset_active_run_history(token)
+
+    print(response)
     return 0
+
+
+def _append_run_history(run_history: RunHistory) -> None:
+    try:
+        append_session_jsonl(run_history.session, RUN_HISTORY_PATH)
+    except OSError as exc:
+        print(f"Failed to write run history: {exc}", file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/agent/orchestrator.py
+++ b/agent/orchestrator.py
@@ -1,4 +1,16 @@
+from collections.abc import Iterable
+from typing import Any
+
+from strands.hooks.events import (
+    AfterInvocationEvent,
+    AfterToolCallEvent,
+    BeforeInvocationEvent,
+    BeforeToolCallEvent,
+    MessageAddedEvent,
+)
+
 from .create_ansible_playbook import create_ansible_playbook
+from .run_history import record_event
 from .tools.ansible import get_ansible_playbook_registry, run_ansible_playbook
 from .utils import build_agent, build_model
 
@@ -22,6 +34,10 @@ Workflow:
 - For simple registry lookup questions, answer using the registry without
   creating or running anything.
 - Do not invent playbook names or paths. Use the registry.
+- Before each tool call, give one short operational sentence explaining what
+  you are about to do and why.
+- Keep those rationale sentences concrete and externally understandable.
+- Do not reveal hidden reasoning or long narration.
 - Keep responses concise and concrete.
 """
 
@@ -29,6 +45,7 @@ Workflow:
 class OrchestratorAgent:
     def __init__(self, *, thinking: ThinkingLevel = "medium") -> None:
         _ = thinking
+        self._latest_rationale: str | None = None
         self.agent = build_agent(
             model=build_model(model_id="gpt-5.4"),
             system_prompt=MAIN_SYSTEM_PROMPT,
@@ -38,6 +55,150 @@ class OrchestratorAgent:
                 create_ansible_playbook,
             ],
         )
+        self.agent.add_hook(self._on_before_invocation, BeforeInvocationEvent)
+        self.agent.add_hook(self._on_message_added, MessageAddedEvent)
+        self.agent.add_hook(self._on_before_tool_call, BeforeToolCallEvent)
+        self.agent.add_hook(self._on_after_tool_call, AfterToolCallEvent)
+        self.agent.add_hook(self._on_after_invocation, AfterInvocationEvent)
 
     def run(self, prompt: str) -> str:
         return str(self.agent(prompt)).strip()
+
+    def _on_before_invocation(self, event: BeforeInvocationEvent) -> None:
+        self._latest_rationale = None
+        record_event(
+            kind="orchestrator_invocation_started",
+            status="started",
+            what="Started orchestrator invocation.",
+            why="Begin selecting whether to inspect, create, or run automation.",
+            details={"message_count": len(event.messages or [])},
+        )
+
+    def _on_message_added(self, event: MessageAddedEvent) -> None:
+        role = _get_message_field(event.message, "role")
+        if role != "assistant":
+            return
+
+        text = _extract_message_text(event.message)
+        if not text:
+            return
+
+        self._latest_rationale = text
+
+    def _on_before_tool_call(self, event: BeforeToolCallEvent) -> None:
+        tool_name = _tool_name_from_use(event.tool_use)
+        tool_arguments = _tool_arguments_from_use(event.tool_use)
+        record_event(
+            kind="tool_call_requested",
+            status="started",
+            what=f"Preparing to call tool `{tool_name}`.",
+            why=self._latest_rationale or _fallback_rationale(),
+            details={"tool_name": tool_name, "arguments": tool_arguments},
+        )
+
+    def _on_after_tool_call(self, event: AfterToolCallEvent) -> None:
+        tool_name = _tool_name_from_use(event.tool_use)
+        if event.exception is not None:
+            record_event(
+                kind="tool_call_completed",
+                status="failed",
+                what=f"Tool `{tool_name}` failed.",
+                why=self._latest_rationale or _fallback_rationale(),
+                details={
+                    "tool_name": tool_name,
+                    "error": str(event.exception),
+                    "exception_type": event.exception.__class__.__name__,
+                },
+            )
+            return
+
+        record_event(
+            kind="tool_call_completed",
+            status="completed",
+            what=f"Tool `{tool_name}` completed.",
+            why=self._latest_rationale or _fallback_rationale(),
+            details={
+                "tool_name": tool_name,
+                "result_preview": _summarize_value(event.result),
+            },
+        )
+
+    def _on_after_invocation(self, event: AfterInvocationEvent) -> None:
+        stop_reason = None
+        if event.result is not None:
+            stop_reason = getattr(event.result, "stop_reason", None)
+
+        record_event(
+            kind="orchestrator_invocation_completed",
+            status="completed",
+            what="Finished orchestrator invocation.",
+            why="The orchestrator has completed its tool selection loop for this request.",
+            details={"stop_reason": str(stop_reason) if stop_reason is not None else None},
+        )
+
+
+def _get_message_field(message: Any, field_name: str) -> Any:
+    if isinstance(message, dict):
+        return message.get(field_name)
+    return getattr(message, field_name, None)
+
+
+def _extract_message_text(message: Any) -> str | None:
+    content = _get_message_field(message, "content")
+    if isinstance(content, str):
+        return content.strip() or None
+
+    if not isinstance(content, Iterable):
+        return None
+
+    parts: list[str] = []
+    for block in content:
+        if isinstance(block, dict):
+            text = block.get("text")
+            if isinstance(text, str) and text.strip():
+                parts.append(text.strip())
+                continue
+            nested_text = block.get("content")
+            if isinstance(nested_text, str) and nested_text.strip():
+                parts.append(nested_text.strip())
+        else:
+            text = getattr(block, "text", None)
+            if isinstance(text, str) and text.strip():
+                parts.append(text.strip())
+
+    if not parts:
+        return None
+    return " ".join(parts)
+
+
+def _tool_name_from_use(tool_use: Any) -> str:
+    if isinstance(tool_use, dict):
+        name = tool_use.get("name")
+        if isinstance(name, str) and name:
+            return name
+    name = getattr(tool_use, "name", None)
+    if isinstance(name, str) and name:
+        return name
+    return "unknown_tool"
+
+
+def _tool_arguments_from_use(tool_use: Any) -> dict[str, Any]:
+    if isinstance(tool_use, dict):
+        tool_input = tool_use.get("input")
+        if isinstance(tool_input, dict):
+            return dict(tool_input)
+    tool_input = getattr(tool_use, "input", None)
+    if isinstance(tool_input, dict):
+        return dict(tool_input)
+    return {}
+
+
+def _summarize_value(value: Any) -> str:
+    preview = str(value).strip()
+    if len(preview) <= 200:
+        return preview
+    return f"{preview[:197]}..."
+
+
+def _fallback_rationale() -> str:
+    return "Tool selected by orchestrator to satisfy the current request."

--- a/agent/playbook_metadata.py
+++ b/agent/playbook_metadata.py
@@ -2,6 +2,7 @@ from typing import Literal
 
 from pydantic import BaseModel, Field
 
+from .run_history import record_event
 from .utils import build_agent, build_model
 
 SYSTEM_PROMPT = """
@@ -58,4 +59,32 @@ class PlaybookMetadataAgent:
 
     def run(self, *, yaml: str) -> GeneratedPlaybookMetadata:
         metadata_prompt = build_metadata_prompt(yaml)
-        return self.agent.structured_output(GeneratedPlaybookMetadata, metadata_prompt)
+        record_event(
+            kind="playbook_metadata_generation_started",
+            status="started",
+            what="Started structured metadata generation.",
+            why=(
+                "Draft registry metadata that matches the generated playbook before any file write."
+            ),
+            details={},
+        )
+        try:
+            metadata = self.agent.structured_output(GeneratedPlaybookMetadata, metadata_prompt)
+        except Exception as exc:
+            record_event(
+                kind="playbook_metadata_generation_failed",
+                status="failed",
+                what="Structured metadata generation failed.",
+                why="The model did not return valid metadata for the generated playbook.",
+                details={"error": str(exc), "exception_type": exc.__class__.__name__},
+            )
+            raise
+
+        record_event(
+            kind="playbook_metadata_generation_completed",
+            status="completed",
+            what="Structured metadata generation completed.",
+            why="The playbook now has name, description, target, tags, and approval metadata.",
+            details=metadata.model_dump(),
+        )
+        return metadata

--- a/agent/run_history.py
+++ b/agent/run_history.py
@@ -1,0 +1,160 @@
+import os
+from collections.abc import Mapping
+from contextvars import ContextVar, Token
+from datetime import UTC, datetime
+from pathlib import Path
+from uuid import uuid4
+
+from pydantic import BaseModel, Field
+
+from .config import RUN_HISTORY_ENABLED, secret_manager
+
+MAX_TEXT_LENGTH = 500
+RUN_HISTORY_ENV_VAR = "DEVOPS_AGENT_RUN_HISTORY_ENABLED"
+RUN_HISTORY_PATH = Path("docs/autonomous-devops-run-history.jsonl")
+
+type JSONPrimitive = None | bool | int | float | str
+type JSONValue = JSONPrimitive | list["JSONValue"] | dict[str, "JSONValue"]
+
+_SENSITIVE_FIELD_MARKERS = ("secret", "token", "password", "key", "private_key")
+_active_run_history: ContextVar["RunHistory | None"] = ContextVar(
+    "active_run_history", default=None
+)
+
+
+class RunEvent(BaseModel):
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    kind: str
+    status: str
+    what: str
+    why: str | None = None
+    details: dict[str, JSONValue] = Field(default_factory=dict)
+
+
+class RunSession(BaseModel):
+    run_id: str
+    started_at: datetime
+    finished_at: datetime | None = None
+    prompt: str
+    outcome: str | None = None
+    events: list[RunEvent] = Field(default_factory=list)
+
+
+def run_history_enabled() -> bool:
+    return bool(secret_manager.get(bool, RUN_HISTORY_ENV_VAR, RUN_HISTORY_ENABLED))
+
+
+class RunHistory:
+    def __init__(self, *, prompt: str) -> None:
+        self.session = RunSession(
+            run_id=uuid4().hex,
+            started_at=datetime.now(UTC),
+            prompt=prompt,
+        )
+
+    def record_event(
+        self,
+        *,
+        kind: str,
+        status: str,
+        what: str,
+        why: str | None = None,
+        details: Mapping[str, object] | None = None,
+    ) -> RunEvent:
+        event = RunEvent(
+            kind=_truncate_required_text(kind),
+            status=_truncate_required_text(status),
+            what=_truncate_required_text(what),
+            why=_truncate_text(why),
+            details=_sanitize_details(details or {}),
+        )
+        self.session.events.append(event)
+        return event
+
+    def finalize(self, outcome: str) -> None:
+        self.session.finished_at = datetime.now(UTC)
+        self.session.outcome = _truncate_text(outcome)
+
+
+def set_active_run_history(run_history: RunHistory | None) -> Token[RunHistory | None]:
+    return _active_run_history.set(run_history)
+
+
+def reset_active_run_history(token: Token[RunHistory | None]) -> None:
+    _active_run_history.reset(token)
+
+
+def get_active_run_history() -> RunHistory | None:
+    return _active_run_history.get()
+
+
+def record_event(
+    *,
+    kind: str,
+    status: str,
+    what: str,
+    why: str | None = None,
+    details: Mapping[str, object] | None = None,
+) -> None:
+    run_history = get_active_run_history()
+    if run_history is None:
+        return
+    run_history.record_event(
+        kind=kind,
+        status=status,
+        what=what,
+        why=why,
+        details=details,
+    )
+
+
+def append_session_jsonl(session: RunSession, path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(session.model_dump_json())
+        handle.write(os.linesep)
+
+
+def _sanitize_details(details: Mapping[str, object]) -> dict[str, JSONValue]:
+    sanitized: dict[str, JSONValue] = {}
+    for key, value in details.items():
+        if _is_sensitive_key(key):
+            sanitized[key] = "[REDACTED]"
+            continue
+        sanitized[key] = _sanitize_json(value)
+    return sanitized
+
+
+def _sanitize_json(value: object) -> JSONValue:
+    if isinstance(value, dict):
+        return _sanitize_details({str(key): item for key, item in value.items()})
+
+    if isinstance(value, list):
+        return [_sanitize_json(item) for item in value]
+
+    if isinstance(value, str):
+        return _truncate_text(value)
+
+    if value is None or isinstance(value, bool | int | float):
+        return value
+
+    return _truncate_text(str(value)) or ""
+
+
+def _is_sensitive_key(key: str) -> bool:
+    normalized = key.lower()
+    return any(marker in normalized for marker in _SENSITIVE_FIELD_MARKERS)
+
+
+def _truncate_text(value: str | None) -> str | None:
+    if value is None:
+        return None
+    if len(value) <= MAX_TEXT_LENGTH:
+        return value
+    return f"{value[: MAX_TEXT_LENGTH - 3]}..."
+
+
+def _truncate_required_text(value: str) -> str:
+    truncated = _truncate_text(value)
+    assert truncated is not None
+    return truncated

--- a/agent/tools/ansible.py
+++ b/agent/tools/ansible.py
@@ -4,6 +4,7 @@ import os
 import pathlib
 import re
 import subprocess
+import time
 import unicodedata
 from functools import lru_cache
 from typing import Final
@@ -11,6 +12,8 @@ from typing import Final
 import yaml
 from pydantic import BaseModel, ValidationError
 from strands import tool
+
+from ..run_history import record_event
 
 logger = logging.getLogger(__name__)
 
@@ -133,7 +136,15 @@ def get_ansible_inventory_groups() -> list[str]:
     """Return the supported top-level inventory groups from ansible/inventory.ini."""
     parser = configparser.ConfigParser(allow_no_value=True)
     parser.read(INVENTORY_PATH, encoding="utf-8")
-    return sorted(section for section in parser.sections() if ":" not in section)
+    groups = sorted(section for section in parser.sections() if ":" not in section)
+    record_event(
+        kind="inventory_groups_read",
+        status="completed",
+        what="Read supported inventory groups.",
+        why="Playbook generation uses the inventory groups to target control, cluster, or both.",
+        details={"groups": groups},
+    )
+    return groups
 
 
 @tool
@@ -148,6 +159,13 @@ def get_ansible_playbook_registry() -> list[dict[str, str | bool | list[str]]]:
         for file in sorted(PLAYBOOKS_DIR.iterdir())
         if file.is_file() and file.suffix in [".yaml", ".yml"]
     ]
+    record_event(
+        kind="playbook_registry_read",
+        status="completed",
+        what="Read the playbook registry.",
+        why="Inspect existing automation before creating or executing a playbook.",
+        details={"count": len(registry), "paths": [str(entry["path"]) for entry in registry]},
+    )
     return registry
 
 
@@ -167,11 +185,43 @@ def run_ansible_playbook(playbook_path: str) -> str:
         RuntimeError: If ansible-playbook exits with a non-zero status.
     """
     entry = _get_registry_entry_by_path(playbook_path)
+    record_event(
+        kind="playbook_execution_requested",
+        status="started",
+        what=f"Requested execution for playbook `{playbook_path}`.",
+        why="The orchestrator selected this existing playbook from the validated registry.",
+        details={"playbook_path": playbook_path, "requires_approval": entry.requires_approval},
+    )
 
     if entry.requires_approval and not _confirm_playbook_execution(entry):
+        record_event(
+            kind="playbook_execution_declined",
+            status="declined",
+            what=f"Declined execution for playbook `{playbook_path}`.",
+            why="This playbook requires explicit human approval before execution.",
+            details={"playbook_path": playbook_path, "approved": False},
+        )
         raise PermissionError(f"Execution not approved for playbook: {playbook_path}")
 
+    record_event(
+        kind="playbook_execution_approved",
+        status="approved",
+        what=f"Approved execution for playbook `{playbook_path}`.",
+        why=(
+            "Execution can proceed once the registry entry is approved or "
+            "does not require approval."
+        ),
+        details={"playbook_path": playbook_path, "approved": True},
+    )
     command = ["ansible-playbook", playbook_path, "-vv"]
+    record_event(
+        kind="playbook_execution_started",
+        status="started",
+        what=f"Started playbook execution for `{playbook_path}`.",
+        why="Run the selected playbook through ansible-playbook with verbose output.",
+        details={"playbook_path": playbook_path, "command": command},
+    )
+    started_at = time.monotonic()
 
     try:
         result = subprocess.run(
@@ -182,12 +232,53 @@ def run_ansible_playbook(playbook_path: str) -> str:
             stderr=subprocess.PIPE,
             text=True,
         )
-        return _decode_output(result.stdout)
+        stdout = _decode_output(result.stdout)
+        elapsed_seconds = round(time.monotonic() - started_at, 3)
+        record_event(
+            kind="playbook_execution_succeeded",
+            status="completed",
+            what=f"Playbook `{playbook_path}` completed successfully.",
+            why="Capture a compact execution summary after ansible-playbook exits cleanly.",
+            details={
+                "playbook_path": playbook_path,
+                "command": command,
+                "elapsed_seconds": elapsed_seconds,
+                "stdout_summary": _summarize_ansible_output(stdout),
+            },
+        )
+        return stdout
     except subprocess.CalledProcessError as exc:
         logger.exception("Ansible playbook execution failed")
         stdout = _decode_output(exc.stdout).strip()
         stderr = _decode_output(exc.stderr).strip()
+        elapsed_seconds = round(time.monotonic() - started_at, 3)
+        record_event(
+            kind="playbook_execution_failed",
+            status="failed",
+            what=f"Playbook `{playbook_path}` failed.",
+            why="Capture the failing command and compact stderr/stdout details for review.",
+            details={
+                "playbook_path": playbook_path,
+                "command": command,
+                "elapsed_seconds": elapsed_seconds,
+                "stdout_summary": _summarize_ansible_output(stdout),
+                "stderr_summary": _summarize_ansible_output(stderr),
+            },
+        )
         details = "\n".join(part for part in (stderr, stdout) if part)
         if details:
             raise RuntimeError(f"Ansible playbook execution failed:\n{details}") from exc
         raise RuntimeError("Ansible playbook execution failed") from exc
+
+
+def _summarize_ansible_output(output: str) -> str:
+    normalized = output.strip()
+    if not normalized:
+        return ""
+
+    play_recap_index = normalized.rfind("PLAY RECAP")
+    if play_recap_index != -1:
+        return normalized[play_recap_index:]
+
+    lines = [line for line in normalized.splitlines() if line.strip()]
+    return "\n".join(lines[-10:])

--- a/ansible/playbooks/display-current-time.yaml
+++ b/ansible/playbooks/display-current-time.yaml
@@ -1,0 +1,22 @@
+# name: display_current_time
+# description: Retrieve and display the current time on all servers
+# target: both
+# requires_approval: false
+# tags:
+#   - time
+#   - debug
+#   - info
+
+---
+- name: Get and display current time on all servers
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Get current time
+      ansible.builtin.command: date
+      register: current_time
+      changed_when: false
+
+    - name: Display current time for each host
+      ansible.builtin.debug:
+        msg: "{{ inventory_hostname }}: {{ current_time.stdout }}"

--- a/docs/autonomous-devops-run-history.json
+++ b/docs/autonomous-devops-run-history.json
@@ -1,0 +1,372 @@
+{
+    "run_id": "4a9959f70972417393d2068017e845cd",
+    "started_at": "2026-04-10T04:45:02.424169Z",
+    "finished_at": "2026-04-10T04:45:26.051000Z",
+    "prompt": "get the time on all servers",
+    "outcome": "I ran the time check playbook.\n\nResults from reachable remote servers:\n- tp1: Thu 9 Apr 23:45:22 CDT 2026\n- tp2: Thu 9 Apr 23:45:23 CDT 2026\n- tp3: Thu 9 Apr 23:45:22 CDT 2026\n- tp4: Thu 9 Apr 23:45:22 CDT 2026\n\nNote:\n- localhost failed due to a Python interpreter issue: `/usr/bin/python3.13` not found.\n\nIf you want, I can create/fix a playbook to avoid localhost or correct the interpreter setting.",
+    "events": [
+        {
+            "timestamp": "2026-04-10T04:45:02.424456Z",
+            "kind": "run_started",
+            "status": "started",
+            "what": "Started CLI invocation.",
+            "why": "Capture the initial user request before orchestration begins.",
+            "details": {
+                "prompt": "get the time on all servers"
+            }
+        },
+        {
+            "timestamp": "2026-04-10T04:45:02.425446Z",
+            "kind": "orchestrator_invocation_started",
+            "status": "started",
+            "what": "Started orchestrator invocation.",
+            "why": "Begin selecting whether to inspect, create, or run automation.",
+            "details": {
+                "message_count": 1
+            }
+        },
+        {
+            "timestamp": "2026-04-10T04:45:05.317450Z",
+            "kind": "tool_call_requested",
+            "status": "started",
+            "what": "Preparing to call tool `get_ansible_playbook_registry`.",
+            "why": "I’m checking the validated playbook registry to find existing automation for collecting time from all servers.",
+            "details": {
+                "tool_name": "get_ansible_playbook_registry",
+                "arguments": {}
+            }
+        },
+        {
+            "timestamp": "2026-04-10T04:45:05.321198Z",
+            "kind": "playbook_registry_read",
+            "status": "completed",
+            "what": "Read the playbook registry.",
+            "why": "Inspect existing automation before creating or executing a playbook.",
+            "details": {
+                "count": 4,
+                "paths": [
+                    "ansible/playbooks/hello-cluster.yaml",
+                    "ansible/playbooks/hello-control.yaml",
+                    "ansible/playbooks/hello-local-test.yaml",
+                    "ansible/playbooks/list-files.yaml"
+                ]
+            }
+        },
+        {
+            "timestamp": "2026-04-10T04:45:05.321591Z",
+            "kind": "tool_call_completed",
+            "status": "completed",
+            "what": "Tool `get_ansible_playbook_registry` completed.",
+            "why": "I’m checking the validated playbook registry to find existing automation for collecting time from all servers.",
+            "details": {
+                "tool_name": "get_ansible_playbook_registry",
+                "result_preview": "{'toolUseId': 'call_WfKgXEqtcJxdpskGpurn4xs3', 'status': 'success', 'content': [{'text': '[{\"name\": \"hello-cluster\", \"description\": \"Ping the cluster node group.\", \"target\": \"cluster\", \"requires_ap..."
+            }
+        },
+        {
+            "timestamp": "2026-04-10T04:45:07.452661Z",
+            "kind": "tool_call_requested",
+            "status": "started",
+            "what": "Preparing to call tool `create_ansible_playbook`.",
+            "why": "I’m creating a new playbook because the registry does not yet include a time-check workflow for all servers.",
+            "details": {
+                "tool_name": "create_ansible_playbook",
+                "arguments": {
+                    "query": "Create an Ansible playbook that gets the current time on all servers and displays the result for each host."
+                }
+            }
+        },
+        {
+            "timestamp": "2026-04-10T04:45:07.453455Z",
+            "kind": "playbook_generation_started",
+            "status": "started",
+            "what": "Started generating a new playbook.",
+            "why": "The registry did not contain a suitable existing playbook for the request.",
+            "details": {
+                "query": "Create an Ansible playbook that gets the current time on all servers and displays the result for each host."
+            }
+        },
+        {
+            "timestamp": "2026-04-10T04:45:07.453476Z",
+            "kind": "structured_playbook_generation_started",
+            "status": "started",
+            "what": "Started structured playbook generation.",
+            "why": "Translate the user request into valid Ansible YAML before any file write.",
+            "details": {
+                "prompt": "Create an Ansible playbook that gets the current time on all servers and displays the result for each host."
+            }
+        },
+        {
+            "timestamp": "2026-04-10T04:45:09.439584Z",
+            "kind": "structured_playbook_generation_completed",
+            "status": "completed",
+            "what": "Structured playbook generation completed.",
+            "why": "The generated YAML passed validation as a non-empty playbook list.",
+            "details": {
+                "hosts": [
+                    "all"
+                ],
+                "task_count": 2
+            }
+        },
+        {
+            "timestamp": "2026-04-10T04:45:09.440061Z",
+            "kind": "playbook_yaml_generated",
+            "status": "completed",
+            "what": "Generated playbook YAML.",
+            "why": "Draft the requested automation before reviewing metadata and filename.",
+            "details": {
+                "hosts": [
+                    "all"
+                ],
+                "task_count": 2
+            }
+        },
+        {
+            "timestamp": "2026-04-10T04:45:09.440075Z",
+            "kind": "playbook_metadata_generation_started",
+            "status": "started",
+            "what": "Started structured metadata generation.",
+            "why": "Draft registry metadata that matches the generated playbook before any file write.",
+            "details": {}
+        },
+        {
+            "timestamp": "2026-04-10T04:45:10.469599Z",
+            "kind": "playbook_metadata_generation_completed",
+            "status": "completed",
+            "what": "Structured metadata generation completed.",
+            "why": "The playbook now has name, description, target, tags, and approval metadata.",
+            "details": {
+                "name": "display_current_time",
+                "description": "Retrieve and display the current time on all servers",
+                "target": "both",
+                "tags": [
+                    "time",
+                    "debug",
+                    "info"
+                ],
+                "requires_approval": false
+            }
+        },
+        {
+            "timestamp": "2026-04-10T04:45:10.469633Z",
+            "kind": "playbook_metadata_generated",
+            "status": "completed",
+            "what": "Generated playbook metadata.",
+            "why": "Summarize the new playbook with registry-friendly fields before any write.",
+            "details": {
+                "name": "display_current_time",
+                "description": "Retrieve and display the current time on all servers",
+                "target": "both",
+                "requires_approval": false,
+                "tags": [
+                    "time",
+                    "debug",
+                    "info"
+                ]
+            }
+        },
+        {
+            "timestamp": "2026-04-10T04:45:10.469792Z",
+            "kind": "playbook_preview_presented",
+            "status": "completed",
+            "what": "Presented the generated playbook preview.",
+            "why": "Show the path, metadata, and YAML before asking for write approval.",
+            "details": {
+                "path": "ansible/playbooks/display-current-time.yaml",
+                "hosts": [
+                    "all"
+                ],
+                "task_count": 2
+            }
+        },
+        {
+            "timestamp": "2026-04-10T04:45:15.554386Z",
+            "kind": "playbook_write_approved",
+            "status": "approved",
+            "what": "Playbook write was approved.",
+            "why": "The generated playbook is ready to be written under ansible/playbooks.",
+            "details": {
+                "path": "ansible/playbooks/display-current-time.yaml",
+                "approved": true
+            }
+        },
+        {
+            "timestamp": "2026-04-10T04:45:15.556036Z",
+            "kind": "playbook_written",
+            "status": "completed",
+            "what": "Wrote the generated playbook file.",
+            "why": "Persist the approved playbook so it can be validated and executed through the registry.",
+            "details": {
+                "path": "ansible/playbooks/display-current-time.yaml"
+            }
+        },
+        {
+            "timestamp": "2026-04-10T04:45:15.556306Z",
+            "kind": "tool_call_completed",
+            "status": "completed",
+            "what": "Tool `create_ansible_playbook` completed.",
+            "why": "I’m creating a new playbook because the registry does not yet include a time-check workflow for all servers.",
+            "details": {
+                "tool_name": "create_ansible_playbook",
+                "result_preview": "{'toolUseId': 'call_WHUubXVthYi5TBQwkdVYFbZh', 'status': 'success', 'content': [{'text': 'ansible/playbooks/display-current-time.yaml'}]}"
+            }
+        },
+        {
+            "timestamp": "2026-04-10T04:45:16.571393Z",
+            "kind": "tool_call_requested",
+            "status": "started",
+            "what": "Preparing to call tool `get_ansible_playbook_registry`.",
+            "why": "I’m refreshing the registry so I can confirm the new playbook path before execution.",
+            "details": {
+                "tool_name": "get_ansible_playbook_registry",
+                "arguments": {}
+            }
+        },
+        {
+            "timestamp": "2026-04-10T04:45:16.585351Z",
+            "kind": "playbook_registry_read",
+            "status": "completed",
+            "what": "Read the playbook registry.",
+            "why": "Inspect existing automation before creating or executing a playbook.",
+            "details": {
+                "count": 5,
+                "paths": [
+                    "ansible/playbooks/display-current-time.yaml",
+                    "ansible/playbooks/hello-cluster.yaml",
+                    "ansible/playbooks/hello-control.yaml",
+                    "ansible/playbooks/hello-local-test.yaml",
+                    "ansible/playbooks/list-files.yaml"
+                ]
+            }
+        },
+        {
+            "timestamp": "2026-04-10T04:45:16.585670Z",
+            "kind": "tool_call_completed",
+            "status": "completed",
+            "what": "Tool `get_ansible_playbook_registry` completed.",
+            "why": "I’m refreshing the registry so I can confirm the new playbook path before execution.",
+            "details": {
+                "tool_name": "get_ansible_playbook_registry",
+                "result_preview": "{'toolUseId': 'call_Jn7xWvTG6TQehUYpVrdEGV3A', 'status': 'success', 'content': [{'text': '[{\"name\": \"display_current_time\", \"description\": \"Retrieve and display the current time on all servers\", \"t..."
+            }
+        },
+        {
+            "timestamp": "2026-04-10T04:45:17.703304Z",
+            "kind": "tool_call_requested",
+            "status": "started",
+            "what": "Preparing to call tool `run_ansible_playbook`.",
+            "why": "I’m running the validated time-display playbook on all servers now.",
+            "details": {
+                "tool_name": "run_ansible_playbook",
+                "arguments": {
+                    "playbook_path": "ansible/playbooks/display-current-time.yaml"
+                }
+            }
+        },
+        {
+            "timestamp": "2026-04-10T04:45:17.707344Z",
+            "kind": "playbook_registry_read",
+            "status": "completed",
+            "what": "Read the playbook registry.",
+            "why": "Inspect existing automation before creating or executing a playbook.",
+            "details": {
+                "count": 5,
+                "paths": [
+                    "ansible/playbooks/display-current-time.yaml",
+                    "ansible/playbooks/hello-cluster.yaml",
+                    "ansible/playbooks/hello-control.yaml",
+                    "ansible/playbooks/hello-local-test.yaml",
+                    "ansible/playbooks/list-files.yaml"
+                ]
+            }
+        },
+        {
+            "timestamp": "2026-04-10T04:45:17.707379Z",
+            "kind": "playbook_execution_requested",
+            "status": "started",
+            "what": "Requested execution for playbook `ansible/playbooks/display-current-time.yaml`.",
+            "why": "The orchestrator selected this existing playbook from the validated registry.",
+            "details": {
+                "playbook_path": "ansible/playbooks/display-current-time.yaml",
+                "requires_approval": false
+            }
+        },
+        {
+            "timestamp": "2026-04-10T04:45:17.707386Z",
+            "kind": "playbook_execution_approved",
+            "status": "approved",
+            "what": "Approved execution for playbook `ansible/playbooks/display-current-time.yaml`.",
+            "why": "Execution can proceed once the registry entry is approved or does not require approval.",
+            "details": {
+                "playbook_path": "ansible/playbooks/display-current-time.yaml",
+                "approved": true
+            }
+        },
+        {
+            "timestamp": "2026-04-10T04:45:17.707391Z",
+            "kind": "playbook_execution_started",
+            "status": "started",
+            "what": "Started playbook execution for `ansible/playbooks/display-current-time.yaml`.",
+            "why": "Run the selected playbook through ansible-playbook with verbose output.",
+            "details": {
+                "playbook_path": "ansible/playbooks/display-current-time.yaml",
+                "command": [
+                    "ansible-playbook",
+                    "ansible/playbooks/display-current-time.yaml",
+                    "-vv"
+                ]
+            }
+        },
+        {
+            "timestamp": "2026-04-10T04:45:24.010755Z",
+            "kind": "playbook_execution_failed",
+            "status": "failed",
+            "what": "Playbook `ansible/playbooks/display-current-time.yaml` failed.",
+            "why": "Capture the failing command and compact stderr/stdout details for review.",
+            "details": {
+                "playbook_path": "ansible/playbooks/display-current-time.yaml",
+                "command": [
+                    "ansible-playbook",
+                    "ansible/playbooks/display-current-time.yaml",
+                    "-vv"
+                ],
+                "elapsed_seconds": 6.303,
+                "stdout_summary": "PLAY RECAP *********************************************************************\nlocalhost                  : ok=0    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0   \ntp1                        : ok=2    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   \ntp2                        : ok=2    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   \ntp3                        : ok=2    changed=0    unreachable=...",
+                "stderr_summary": ""
+            }
+        },
+        {
+            "timestamp": "2026-04-10T04:45:24.011309Z",
+            "kind": "tool_call_completed",
+            "status": "failed",
+            "what": "Tool `run_ansible_playbook` failed.",
+            "why": "I’m running the validated time-display playbook on all servers now.",
+            "details": {
+                "tool_name": "run_ansible_playbook",
+                "error": "Ansible playbook execution failed:\nansible-playbook [core 2.17.6]\n  config file = /Users/alysivji/conductor/workspaces/devops-agent/muscat/ansible.cfg\n  configured module search path = ['/Users/alysivji/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']\n  ansible python module location = /opt/homebrew/Cellar/ansible/10.6.0/libexec/lib/python3.12/site-packages/ansible\n  ansible collection location = /Users/alysivji/.ansible/collections:/usr/share/ansible/collections\n  executable ...",
+                "exception_type": "RuntimeError"
+            }
+        },
+        {
+            "timestamp": "2026-04-10T04:45:26.050010Z",
+            "kind": "orchestrator_invocation_completed",
+            "status": "completed",
+            "what": "Finished orchestrator invocation.",
+            "why": "The orchestrator has completed its tool selection loop for this request.",
+            "details": {
+                "stop_reason": "end_turn"
+            }
+        },
+        {
+            "timestamp": "2026-04-10T04:45:26.050986Z",
+            "kind": "run_completed",
+            "status": "completed",
+            "what": "CLI invocation completed successfully.",
+            "why": "Persist the final agent response for later review.",
+            "details": {
+                "response": "I ran the time check playbook.\n\nResults from reachable remote servers:\n- tp1: Thu 9 Apr 23:45:22 CDT 2026\n- tp2: Thu 9 Apr 23:45:23 CDT 2026\n- tp3: Thu 9 Apr 23:45:22 CDT 2026\n- tp4: Thu 9 Apr 23:45:22 CDT 2026\n\nNote:\n- localhost failed due to a Python interpreter issue: `/usr/bin/python3.13` not found.\n\nIf you want, I can create/fix a playbook to avoid localhost or correct the interpreter setting."
+            }
+        }
+    ]
+}

--- a/tests/test_create_ansible_playbook.py
+++ b/tests/test_create_ansible_playbook.py
@@ -1,0 +1,112 @@
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+
+from agent.create_ansible_playbook import CreateAnsiblePlaybookWorkflow
+from agent.playbook_metadata import GeneratedPlaybookMetadata
+from agent.run_history import RunHistory, reset_active_run_history, set_active_run_history
+
+
+class StubGenerator:
+    def __init__(self, yaml_text: str) -> None:
+        self.yaml_text = yaml_text
+
+    def run(self, prompt: str) -> SimpleNamespace:
+        return SimpleNamespace(yaml=self.yaml_text)
+
+
+class StubMetadataAgent:
+    def __init__(self, metadata: GeneratedPlaybookMetadata) -> None:
+        self.metadata = metadata
+
+    def run(self, *, yaml: str) -> GeneratedPlaybookMetadata:
+        return self.metadata
+
+
+def test_create_playbook_records_approved_write(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "agent.create_ansible_playbook.PLAYBOOKS_DIR", tmp_path / "ansible" / "playbooks"
+    )
+    (tmp_path / "ansible" / "playbooks").mkdir(parents=True)
+    monkeypatch.setattr("builtins.input", lambda _: "y")
+
+    metadata = GeneratedPlaybookMetadata(
+        name="hello-control",
+        description="Ping the control node group.",
+        target="control",
+        tags=["connectivity"],
+        requires_approval=True,
+    )
+    workflow = CreateAnsiblePlaybookWorkflow(
+        generator=cast(
+            Any,
+            StubGenerator(
+                "- hosts: control\n  tasks:\n    - name: Ping\n      ansible.builtin.ping:\n"
+            ),
+        ),
+        metadata_agent=cast(Any, StubMetadataAgent(metadata)),
+    )
+    run_history = RunHistory(prompt="create a ping playbook")
+    token = set_active_run_history(run_history)
+
+    try:
+        result = workflow.run("create a ping playbook")
+    finally:
+        reset_active_run_history(token)
+
+    event_kinds = [event.kind for event in run_history.session.events]
+
+    assert result.written is True
+    assert "playbook_write_approved" in event_kinds
+    assert "playbook_written" in event_kinds
+    yaml_event = next(
+        event for event in run_history.session.events if event.kind == "playbook_yaml_generated"
+    )
+    assert yaml_event.details == {"hosts": ["control"], "task_count": 1}
+
+
+def test_create_playbook_records_declined_write(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        "agent.create_ansible_playbook.PLAYBOOKS_DIR", tmp_path / "ansible" / "playbooks"
+    )
+    (tmp_path / "ansible" / "playbooks").mkdir(parents=True)
+    monkeypatch.setattr("builtins.input", lambda _: "n")
+
+    metadata = GeneratedPlaybookMetadata(
+        name="hello-control",
+        description="Ping the control node group.",
+        target="control",
+        tags=["connectivity"],
+        requires_approval=True,
+    )
+    workflow = CreateAnsiblePlaybookWorkflow(
+        generator=cast(
+            Any,
+            StubGenerator(
+                "- hosts: control\n  tasks:\n    - name: Ping\n      ansible.builtin.ping:\n"
+            ),
+        ),
+        metadata_agent=cast(Any, StubMetadataAgent(metadata)),
+    )
+    run_history = RunHistory(prompt="create a ping playbook")
+    token = set_active_run_history(run_history)
+
+    try:
+        result = workflow.run("create a ping playbook")
+    finally:
+        reset_active_run_history(token)
+
+    assert result.written is False
+    event_kinds = [event.kind for event in run_history.session.events]
+    assert "playbook_write_declined" in event_kinds
+    assert "playbook_written" not in event_kinds

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,73 @@
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from agent import main as main_module
+
+
+class SuccessfulOrchestrator:
+    def run(self, prompt: str) -> str:
+        return f"handled: {prompt}"
+
+
+class FailingOrchestrator:
+    def run(self, prompt: str) -> str:
+        raise RuntimeError(f"boom: {prompt}")
+
+
+def test_main_appends_run_history_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("DEVOPS_AGENT_RUN_HISTORY_ENABLED", "true")
+    monkeypatch.setattr(main_module, "OrchestratorAgent", SuccessfulOrchestrator)
+    monkeypatch.setattr(sys, "argv", ["agent.main", "inspect the registry"])
+
+    exit_code = main_module.main()
+
+    captured = capsys.readouterr()
+    output_path = tmp_path / "docs" / "autonomous-devops-run-history.jsonl"
+
+    assert exit_code == 0
+    assert captured.out.strip() == "handled: inspect the registry"
+    payload = json.loads(output_path.read_text(encoding="utf-8").splitlines()[0])
+    assert payload["prompt"] == "inspect the registry"
+    assert payload["outcome"] == "handled: inspect the registry"
+
+
+def test_main_skips_run_history_when_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("DEVOPS_AGENT_RUN_HISTORY_ENABLED", "false")
+    monkeypatch.setattr(main_module, "OrchestratorAgent", SuccessfulOrchestrator)
+    monkeypatch.setattr(sys, "argv", ["agent.main", "inspect the registry"])
+
+    main_module.main()
+
+    output_path = tmp_path / "docs" / "autonomous-devops-run-history.jsonl"
+    assert not output_path.exists()
+
+
+def test_main_records_failed_session_before_reraising(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("DEVOPS_AGENT_RUN_HISTORY_ENABLED", "true")
+    monkeypatch.setattr(main_module, "OrchestratorAgent", FailingOrchestrator)
+    monkeypatch.setattr(sys, "argv", ["agent.main", "inspect the registry"])
+
+    with pytest.raises(RuntimeError, match="boom: inspect the registry"):
+        main_module.main()
+
+    output_path = tmp_path / "docs" / "autonomous-devops-run-history.jsonl"
+    payload = json.loads(output_path.read_text(encoding="utf-8").splitlines()[0])
+
+    assert payload["outcome"] == "failed: boom: inspect the registry"
+    assert payload["events"][-1]["kind"] == "run_failed"

--- a/tests/test_run_history.py
+++ b/tests/test_run_history.py
@@ -1,0 +1,65 @@
+import json
+from pathlib import Path
+
+from agent.run_history import RunHistory, append_session_jsonl, run_history_enabled
+
+
+def test_run_history_enabled_by_default(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "agent.run_history.secret_manager.get",
+        lambda secret_type, name, default: default,
+    )
+
+    assert run_history_enabled() is True
+
+
+def test_run_history_can_be_disabled_with_env_var(monkeypatch) -> None:
+    monkeypatch.setenv("DEVOPS_AGENT_RUN_HISTORY_ENABLED", "false")
+
+    assert run_history_enabled() is False
+
+
+def test_run_history_redacts_sensitive_fields_and_truncates_text() -> None:
+    run_history = RunHistory(prompt="deploy the cluster")
+    run_history.record_event(
+        kind="tool_call",
+        status="completed",
+        what="x" * 600,
+        why="y" * 600,
+        details={
+            "token": "abc123",
+            "nested": {"private_key": "hidden", "note": "z" * 600},
+            "items": [{"password": "secret"}],
+        },
+    )
+
+    event = run_history.session.events[0]
+
+    assert event.what.endswith("...")
+    assert event.why is not None and event.why.endswith("...")
+    assert event.details["token"] == "[REDACTED]"
+    assert event.details["nested"] == {"private_key": "[REDACTED]", "note": ("z" * 497) + "..."}
+    assert event.details["items"] == [{"password": "[REDACTED]"}]
+
+
+def test_append_session_jsonl_persists_prompt_and_outcome(tmp_path: Path) -> None:
+    output_path = tmp_path / "docs" / "autonomous-devops-run-history.jsonl"
+    run_history = RunHistory(prompt="inspect the registry")
+    run_history.record_event(
+        kind="run_started",
+        status="started",
+        what="Started.",
+        why="Capture the prompt.",
+        details={"prompt": "inspect the registry"},
+    )
+    run_history.finalize("used existing playbook")
+
+    append_session_jsonl(run_history.session, output_path)
+
+    lines = output_path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+
+    payload = json.loads(lines[0])
+    assert payload["prompt"] == "inspect the registry"
+    assert payload["outcome"] == "used existing playbook"
+    assert payload["events"][0]["kind"] == "run_started"

--- a/tests/tools/test_ansible.py
+++ b/tests/tools/test_ansible.py
@@ -182,6 +182,14 @@ class TestGetAnsiblePlaybookRegistry:
         assert len(registry) > 0
         assert registry == [
             {
+                "description": "Retrieve and display the current time on all servers",
+                "name": "display_current_time",
+                "path": "ansible/playbooks/display-current-time.yaml",
+                "requires_approval": False,
+                "tags": ["time", "debug", "info"],
+                "target": "both",
+            },
+            {
                 "description": "Ping the cluster node group.",
                 "name": "hello-cluster",
                 "path": "ansible/playbooks/hello-cluster.yaml",

--- a/tests/tools/test_ansible.py
+++ b/tests/tools/test_ansible.py
@@ -3,6 +3,7 @@ from typing import Any, cast
 
 import pytest
 
+from agent.run_history import RunHistory, reset_active_run_history, set_active_run_history
 from agent.tools import (
     get_ansible_inventory_groups,
     get_ansible_playbook_registry,
@@ -46,9 +47,16 @@ class TestRunAnsiblePlaybook:
 
     def test_run_ansible_playbook_requires_approval(self, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.setattr("builtins.input", lambda _: "n")
+        run_history = RunHistory(prompt="run hello-control")
+        token = set_active_run_history(run_history)
 
-        with pytest.raises(PermissionError, match="Execution not approved"):
-            run_ansible_playbook("ansible/playbooks/hello-control.yaml")
+        try:
+            with pytest.raises(PermissionError, match="Execution not approved"):
+                run_ansible_playbook("ansible/playbooks/hello-control.yaml")
+        finally:
+            reset_active_run_history(token)
+
+        assert run_history.session.events[-1].kind == "playbook_execution_declined"
 
     def test_run_ansible_playbook_failure_includes_stderr(self, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.setattr("builtins.input", lambda _: "y")
@@ -115,6 +123,56 @@ class TestRunAnsiblePlaybook:
         assert "LANG" not in env
         assert "LC_CTYPE" not in env
 
+    def test_run_ansible_playbook_success_records_run_history(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("builtins.input", lambda _: "y")
+        run_history = RunHistory(prompt="run hello-control")
+        token = set_active_run_history(run_history)
+
+        def fake_run(*args, **kwargs):
+            return subprocess.CompletedProcess(
+                args=args[0],
+                returncode=0,
+                stdout="PLAY RECAP\ncontrol : ok=1 changed=0 failed=0\n",
+                stderr="",
+            )
+
+        monkeypatch.setattr("agent.tools.ansible.subprocess.run", fake_run)
+
+        try:
+            run_ansible_playbook("ansible/playbooks/hello-control.yaml")
+        finally:
+            reset_active_run_history(token)
+
+        event_kinds = [event.kind for event in run_history.session.events]
+        assert "playbook_execution_succeeded" in event_kinds
+
+    def test_run_ansible_playbook_failure_records_run_history(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr("builtins.input", lambda _: "y")
+        run_history = RunHistory(prompt="run hello-control")
+        token = set_active_run_history(run_history)
+
+        def fake_run(*args, **kwargs):
+            raise subprocess.CalledProcessError(
+                returncode=4,
+                cmd=args[0],
+                output="host unreachable",
+                stderr="inventory parse failed",
+            )
+
+        monkeypatch.setattr("agent.tools.ansible.subprocess.run", fake_run)
+
+        try:
+            with pytest.raises(RuntimeError, match=r"inventory parse failed\s+host unreachable"):
+                run_ansible_playbook("ansible/playbooks/hello-control.yaml")
+        finally:
+            reset_active_run_history(token)
+
+        assert run_history.session.events[-1].kind == "playbook_execution_failed"
+
 
 class TestGetAnsiblePlaybookRegistry:
     def test_get_ansible_playbook_registry(self):
@@ -159,6 +217,17 @@ class TestGetAnsiblePlaybookRegistry:
                 "target": "both",
             },
         ]
+
+    def test_get_ansible_playbook_registry_records_run_history(self) -> None:
+        run_history = RunHistory(prompt="inspect registry")
+        token = set_active_run_history(run_history)
+
+        try:
+            get_ansible_playbook_registry()
+        finally:
+            reset_active_run_history(token)
+
+        assert run_history.session.events[-1].kind == "playbook_registry_read"
 
 
 class TestGetAnsibleInventoryGroups:


### PR DESCRIPTION
## Summary

This adds default-on run history capture for CLI agent sessions so the repo records what the autonomous DevOps flow did and why at each major step. It also includes a generated playbook for checking time across servers and a captured run-history artifact from exercising that workflow.

## Changes

- Added `agent/run_history.py` plus CLI, orchestrator, playbook-generation, and Ansible instrumentation to persist prompts, decisions, tool activity, approvals, declines, and summarized outcomes.
- Added `DEVOPS_AGENT_RUN_HISTORY_ENABLED` config, README documentation, and tests covering run history persistence plus playbook creation and Ansible execution event capture.
- Added `ansible/playbooks/display-current-time.yaml` and `docs/autonomous-devops-run-history.json` to reflect the current workspace-generated automation and recorded session artifact.

## Validation

- [x] `uv run pre-commit run --all-files`
- [x] `uv run mypy`
- [x] `uv run pytest --subprocess-vcr=record`

## Infra Notes

- Deployment, rollout, or operator follow-up: No deployment steps required; operators can disable default capture with `DEVOPS_AGENT_RUN_HISTORY_ENABLED=false` if they do not want session history written.
- Secrets, credentials, or permissions touched: No secrets or permissions were changed; persisted event details redact secret-like keys.
- Ansible, CI, or agent behavior impact: CLI runs now record session history by default, the agent emits explicit operational rationales before tool calls, and the repo now includes a time-check playbook plus one captured run-history artifact.

## Risks

- Known tradeoffs: Run history now stores prompts and summarized outcomes by default, and the checked-in JSON artifact is a point-in-time sample that can become stale.
- Follow-up work: Convert the checked-in artifact flow to the intended JSONL shape and add a separate human-readable talk/export path later.
