### PR TITLE
Rename agent tool functions

### DIFF
--- a/devops_bot/agents/orchestrator.py
+++ b/devops_bot/agents/orchestrator.py
@@ -11,8 +11,8 @@ from strands.hooks.events import (
 
 from ..factory import build_agent, build_model
 from ..history import record_event
-from ..tools.ansible import get_ansible_playbook_registry, run_ansible_playbook
-from ..tools.playbooks import create_ansible_playbook, edit_ansible_playbook
+from ..tools.ansible import ansible_list_playbooks, ansible_run_playbook
+from ..tools.playbooks import ansible_create_playbook, ansible_edit_playbook
 
 ThinkingLevel = str
 
@@ -20,10 +20,10 @@ MAIN_SYSTEM_PROMPT = """
 You orchestrate Ansible playbook tools for this repository.
 
 Available tools:
-- `get_ansible_playbook_registry`: inspect the validated playbook registry
-- `run_ansible_playbook`: execute an existing registry playbook by path
-- `create_ansible_playbook`: generate and write a new playbook through the agent-backed tool
-- `edit_ansible_playbook`: repair an existing registry playbook locally and syntax-check it
+- `ansible_list_playbooks`: inspect the validated playbook registry
+- `ansible_run_playbook`: execute an existing registry playbook by path
+- `ansible_create_playbook`: generate and write a new playbook through the agent-backed tool
+- `ansible_edit_playbook`: repair an existing registry playbook locally and syntax-check it
 
 Process:
 - Start by inspecting the current playbook registry when the request might map
@@ -36,7 +36,7 @@ Process:
   unless the capability-level check is failing. For clustered services, prefer
   cluster/API health over individual service restarts, package state, boot
   flags, or kernel internals.
-- If the registry already contains the right playbook, run it with `run_ansible_playbook`.
+- If the registry already contains the right playbook, run it with `ansible_run_playbook`.
 - If a tool fails while working toward the user's requested end state, do not
   stop after describing the failure. Use the failure details to choose the next
   corrective action available through the tools, then try again.
@@ -48,21 +48,21 @@ Process:
   dependencies, kernel or boot configuration, service configuration, or other
   environment preparation needed for the original request, treat that as missing
   prerequisite automation. Inspect the registry for a matching prerequisite
-  playbook; if none exists, call `create_ansible_playbook` to create one.
+  playbook; if none exists, call `ansible_create_playbook` to create one.
 - If a prerequisite playbook changes configuration but validation shows the live
   host state still differs, do not stop because there is no existing validated
   playbook for deeper inspection. Treat the mismatch as missing
-  diagnostic/remediation automation and use `create_ansible_playbook` to
+  diagnostic/remediation automation and use `ansible_create_playbook` to
   discover the active configuration source and repair it when possible.
 - Do not rerun the exact same failing playbook without first taking a corrective
   action or identifying that the failure was transient.
 - After editing an existing playbook, inspect the registry again and call
-  `run_ansible_playbook` for the same playbook when the original user request
+  `ansible_run_playbook` for the same playbook when the original user request
   still requires execution. Do not stop with a natural-language approval request;
-  `run_ansible_playbook` owns the approval prompt for remote-impacting execution.
+  `ansible_run_playbook` owns the approval prompt for remote-impacting execution.
 - After creating prerequisite automation, inspect the registry and call
-  `run_ansible_playbook` for the prerequisite playbook. If it completes, call
-  `run_ansible_playbook` for the original playbook again when the original user
+  `ansible_run_playbook` for the prerequisite playbook. If it completes, call
+  `ansible_run_playbook` for the original playbook again when the original user
   request still requires execution.
 - Do not end with "if you want, I can..." while there is an available tool call
   that can move the original request forward. Only stop when the requested end
@@ -71,7 +71,7 @@ Process:
 - Do not edit inventory, Python code, docs, or arbitrary files while handling
   an Ansible playbook execution failure.
 - If the registry does not contain the needed automation, create a new playbook
-  with `create_ansible_playbook`.
+  with `ansible_create_playbook`.
 - After creating a new playbook, inspect the registry again and run the appropriate playbook.
 - For simple registry lookup questions, answer using the registry without
   creating or running anything.
@@ -92,10 +92,10 @@ class OrchestratorAgent:
             model=build_model(model_id="gpt-5.4"),
             system_prompt=MAIN_SYSTEM_PROMPT,
             tools=[
-                get_ansible_playbook_registry,
-                run_ansible_playbook,
-                create_ansible_playbook,
-                edit_ansible_playbook,
+                ansible_list_playbooks,
+                ansible_run_playbook,
+                ansible_create_playbook,
+                ansible_edit_playbook,
             ],
         )
         self.agent.add_hook(self._on_before_invocation, BeforeInvocationEvent)

--- a/devops_bot/agents/playbook_generator.py
+++ b/devops_bot/agents/playbook_generator.py
@@ -3,7 +3,7 @@ from pydantic import BaseModel, Field, field_validator
 
 from ..factory import build_agent, build_model
 from ..history import record_event
-from ..tools.ansible import check_ansible_playbook_syntax, get_ansible_inventory_groups
+from ..tools.ansible import ansible_list_inventory_groups, check_ansible_playbook_syntax
 from ..tools.web import http_get, search_web
 
 SYSTEM_PROMPT = """
@@ -101,7 +101,7 @@ class GeneratePlaybookAgent:
         self.agent = build_agent(
             model=build_model(model_id="gpt-5.4"),
             system_prompt=SYSTEM_PROMPT,
-            tools=[get_ansible_inventory_groups, search_web, http_get],
+            tools=[ansible_list_inventory_groups, search_web, http_get],
         )
 
     def run(self, prompt: str) -> GeneratedPlaybookYaml:

--- a/devops_bot/tools/__init__.py
+++ b/devops_bot/tools/__init__.py
@@ -1,26 +1,26 @@
 from .ansible import (
-    get_ansible_inventory_groups,
-    get_ansible_playbook_registry,
-    run_ansible_playbook,
+    ansible_list_inventory_groups,
+    ansible_list_playbooks,
+    ansible_run_playbook,
 )
 from .git import (
-    create_git_branch,
-    create_git_commit,
+    git_create_branch,
+    git_create_commit,
+    git_list_commits,
     git_push,
     git_status,
-    list_git_commits,
 )
 from .web import http_get, search_web
 
 __all__ = [
-    "create_git_branch",
-    "create_git_commit",
-    "get_ansible_inventory_groups",
-    "get_ansible_playbook_registry",
+    "git_create_branch",
+    "git_create_commit",
+    "ansible_list_inventory_groups",
+    "ansible_list_playbooks",
     "git_push",
     "git_status",
     "http_get",
-    "list_git_commits",
-    "run_ansible_playbook",
+    "git_list_commits",
+    "ansible_run_playbook",
     "search_web",
 ]

--- a/devops_bot/tools/ansible.py
+++ b/devops_bot/tools/ansible.py
@@ -151,7 +151,7 @@ def _parse_playbook_metadata(playbook_path: pathlib.Path) -> AnsiblePlaybookRegi
 
 
 def _get_registry_entry_by_path(playbook_path: str) -> AnsiblePlaybookRegistryEntry:
-    for entry in get_ansible_playbook_registry():
+    for entry in ansible_list_playbooks():
         path = entry["path"]
         if path == playbook_path:
             return AnsiblePlaybookRegistryEntry.model_validate(entry)
@@ -206,7 +206,7 @@ def normalize_playbook_name(name: str) -> str:
 
 
 @tool
-def get_ansible_inventory_groups() -> list[str]:
+def ansible_list_inventory_groups() -> list[str]:
     """Return the supported top-level inventory groups from ansible/inventory.ini."""
     parser = configparser.ConfigParser(allow_no_value=True)
     parser.read(INVENTORY_PATH, encoding="utf-8")
@@ -222,7 +222,7 @@ def get_ansible_inventory_groups() -> list[str]:
 
 
 @tool
-def get_ansible_playbook_registry() -> list[AnsiblePlaybookRegistryEntryDict]:
+def ansible_list_playbooks() -> list[AnsiblePlaybookRegistryEntryDict]:
     """Return the Ansible playbook registry with validated metadata.
 
     Returns:
@@ -244,7 +244,7 @@ def get_ansible_playbook_registry() -> list[AnsiblePlaybookRegistryEntryDict]:
 
 
 @tool
-def run_ansible_playbook(playbook_path: str) -> str:
+def ansible_run_playbook(playbook_path: str) -> str:
     """Run a validated Ansible playbook and return its standard output.
 
     Args:

--- a/devops_bot/tools/git.py
+++ b/devops_bot/tools/git.py
@@ -27,7 +27,7 @@ def git_status() -> str:
 
 
 @tool
-def list_git_commits(limit: int = 10) -> str:
+def git_list_commits(limit: int = 10) -> str:
     """Return the most recent commits as one line each."""
     if limit < 1:
         raise ValueError("limit must be at least 1")
@@ -42,7 +42,7 @@ def list_git_commits(limit: int = 10) -> str:
 
 
 @tool
-def create_git_commit(message: str) -> str:
+def git_create_commit(message: str) -> str:
     """Stage all changes, create a git commit, and return the new commit summary."""
     if not message.strip():
         raise ValueError("message must not be empty")
@@ -53,7 +53,7 @@ def create_git_commit(message: str) -> str:
 
 
 @tool
-def create_git_branch(branch_name: str, base_ref: str = "origin/main") -> str:
+def git_create_branch(branch_name: str, base_ref: str = "origin/main") -> str:
     """Create and check out a new branch from a base ref."""
     if not branch_name.strip():
         raise ValueError("branch_name must not be empty")

--- a/devops_bot/tools/playbooks.py
+++ b/devops_bot/tools/playbooks.py
@@ -15,8 +15,8 @@ from ..agents.playbook_generator import GeneratePlaybookAgent
 from ..agents.playbook_metadata import GeneratedPlaybookMetadata, PlaybookMetadataAgent
 from ..history import record_event
 from .ansible import (
+    ansible_list_playbooks,
     check_ansible_playbook_syntax,
-    get_ansible_playbook_registry,
 )
 
 PLAYBOOKS_DIR = Path("ansible/playbooks")
@@ -30,7 +30,7 @@ class CreateAnsiblePlaybookResult(BaseModel):
 
 
 @tool
-def create_ansible_playbook(query: str) -> Path | None:
+def ansible_create_playbook(query: str) -> Path | None:
     """
     Generate an Ansible playbook from a natural-language request.
 
@@ -242,7 +242,7 @@ class AnsiblePlaybookEditor(Protocol):
 
 
 @tool
-def edit_ansible_playbook(
+def ansible_edit_playbook(
     playbook_path: str,
     requested_change: str,
 ) -> EditAnsiblePlaybookToolResult:
@@ -360,7 +360,7 @@ def _validate_registry_playbook_path(playbook_path: str) -> Path:
     if requested_path.is_absolute():
         raise ValueError("playbook path must be relative")
 
-    registry_paths = {entry["path"] for entry in get_ansible_playbook_registry()}
+    registry_paths = {entry["path"] for entry in ansible_list_playbooks()}
     if playbook_path not in registry_paths:
         raise ValueError(f"Playbook path is not in the registry: {playbook_path}")
 

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -5,7 +5,7 @@ def test_orchestrator_prompt_treats_live_state_mismatch_as_actionable() -> None:
     assert "host state still differs" in MAIN_SYSTEM_PROMPT
     assert "diagnostic/remediation automation" in MAIN_SYSTEM_PROMPT
     assert "active configuration source" in MAIN_SYSTEM_PROMPT
-    assert "create_ansible_playbook" in MAIN_SYSTEM_PROMPT
+    assert "ansible_create_playbook" in MAIN_SYSTEM_PROMPT
 
 
 def test_orchestrator_prompt_prefers_goal_state_validation() -> None:

--- a/tests/test_playbook_editing.py
+++ b/tests/test_playbook_editing.py
@@ -59,7 +59,7 @@ class StubEditor:
         return self.edited
 
 
-def test_edit_ansible_playbook_records_approved_write(
+def test_ansible_edit_playbook_records_approved_write(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -104,7 +104,7 @@ def test_edit_ansible_playbook_records_approved_write(
     assert "playbook_edit_written" in event_kinds
 
 
-def test_edit_ansible_playbook_records_declined_write(
+def test_ansible_edit_playbook_records_declined_write(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -145,7 +145,7 @@ def test_edit_ansible_playbook_records_declined_write(
     assert "playbook_edit_written" not in event_kinds
 
 
-def test_edit_ansible_playbook_requires_registry_path(
+def test_ansible_edit_playbook_requires_registry_path(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:

--- a/tests/tools/test_ansible.py
+++ b/tests/tools/test_ansible.py
@@ -5,24 +5,24 @@ import pytest
 
 from devops_bot.history import RunHistory, reset_active_run_history, set_active_run_history
 from devops_bot.tools import (
-    get_ansible_inventory_groups,
-    get_ansible_playbook_registry,
-    run_ansible_playbook,
+    ansible_list_inventory_groups,
+    ansible_list_playbooks,
+    ansible_run_playbook,
 )
 
 
 class TestRunAnsiblePlaybook:
-    def test_run_ansible_playbook_not_found(self):
+    def test_ansible_run_playbook_not_found(self):
         with pytest.raises(ValueError):
-            run_ansible_playbook("playbooks/test_playbook.yml")
+            ansible_run_playbook("playbooks/test_playbook.yml")
 
     @pytest.mark.subprocess_vcr
     def test_run_ansible_playbook_success(self):
-        result = run_ansible_playbook("ansible/playbooks/hello-local-test.yaml")
+        result = ansible_run_playbook("ansible/playbooks/hello-local-test.yaml")
 
         assert "PLAY RECAP" in result
 
-    def test_run_ansible_playbook_uses_default_output(self, monkeypatch: pytest.MonkeyPatch):
+    def test_ansible_run_playbook_uses_default_output(self, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.setattr("builtins.input", lambda _: "y")
 
         recorded: dict[str, object] = {}
@@ -39,24 +39,24 @@ class TestRunAnsiblePlaybook:
 
         monkeypatch.setattr("devops_bot.tools.ansible.subprocess.run", fake_run)
 
-        cast(Any, run_ansible_playbook)("ansible/playbooks/hello-control.yaml")
+        cast(Any, ansible_run_playbook)("ansible/playbooks/hello-control.yaml")
 
         assert recorded["args"] == (["ansible-playbook", "ansible/playbooks/hello-control.yaml"],)
 
-    def test_run_ansible_playbook_requires_approval(self, monkeypatch: pytest.MonkeyPatch):
+    def test_ansible_run_playbook_requires_approval(self, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.setattr("builtins.input", lambda _: "n")
         run_history = RunHistory(prompt="run hello-control")
         token = set_active_run_history(run_history)
 
         try:
             with pytest.raises(PermissionError, match="Execution not approved"):
-                run_ansible_playbook("ansible/playbooks/hello-control.yaml")
+                ansible_run_playbook("ansible/playbooks/hello-control.yaml")
         finally:
             reset_active_run_history(token)
 
         assert run_history.session.events[-1].kind == "playbook_execution_declined"
 
-    def test_run_ansible_playbook_failure_includes_stderr(self, monkeypatch: pytest.MonkeyPatch):
+    def test_ansible_run_playbook_failure_includes_stderr(self, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.setattr("builtins.input", lambda _: "y")
 
         def fake_run(*args, **kwargs):
@@ -70,9 +70,9 @@ class TestRunAnsiblePlaybook:
         monkeypatch.setattr("devops_bot.tools.ansible.subprocess.run", fake_run)
 
         with pytest.raises(RuntimeError, match="inventory parse failed"):
-            run_ansible_playbook("ansible/playbooks/hello-control.yaml")
+            ansible_run_playbook("ansible/playbooks/hello-control.yaml")
 
-    def test_run_ansible_playbook_failure_includes_stdout(self, monkeypatch: pytest.MonkeyPatch):
+    def test_ansible_run_playbook_failure_includes_stdout(self, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.setattr("builtins.input", lambda _: "y")
 
         def fake_run(*args, **kwargs):
@@ -89,9 +89,9 @@ class TestRunAnsiblePlaybook:
             RuntimeError,
             match=r"inventory parse failed[\s\S]+host unreachable",
         ):
-            run_ansible_playbook("ansible/playbooks/hello-control.yaml")
+            ansible_run_playbook("ansible/playbooks/hello-control.yaml")
 
-    def test_run_ansible_playbook_failure_includes_ansible_diagnosis(
+    def test_ansible_run_playbook_failure_includes_ansible_diagnosis(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.setattr("builtins.input", lambda _: "y")
@@ -116,7 +116,7 @@ class TestRunAnsiblePlaybook:
         monkeypatch.setattr("devops_bot.tools.ansible.subprocess.run", fake_run)
 
         with pytest.raises(RuntimeError) as exc_info:
-            run_ansible_playbook("ansible/playbooks/hello-control.yaml")
+            ansible_run_playbook("ansible/playbooks/hello-control.yaml")
 
         message = str(exc_info.value)
         assert "Failed task: Validate k3s server service and API health" in message
@@ -124,7 +124,7 @@ class TestRunAnsiblePlaybook:
         assert "dict method" in message
         assert "stdout tail:" in message
 
-    def test_run_ansible_playbook_removes_unsupported_locale_vars(
+    def test_ansible_run_playbook_removes_unsupported_locale_vars(
         self, monkeypatch: pytest.MonkeyPatch
     ):
         monkeypatch.setattr("builtins.input", lambda _: "y")
@@ -149,7 +149,7 @@ class TestRunAnsiblePlaybook:
         monkeypatch.setenv("LANG", "C.UTF-8")
         monkeypatch.setenv("LC_CTYPE", "C.UTF-8")
 
-        run_ansible_playbook("ansible/playbooks/hello-control.yaml")
+        ansible_run_playbook("ansible/playbooks/hello-control.yaml")
 
         kwargs = cast(dict[str, Any], recorded["kwargs"])
         env = cast(dict[str, str], kwargs["env"])
@@ -157,7 +157,7 @@ class TestRunAnsiblePlaybook:
         assert "LANG" not in env
         assert "LC_CTYPE" not in env
 
-    def test_run_ansible_playbook_success_records_run_history(
+    def test_ansible_run_playbook_success_records_run_history(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.setattr("builtins.input", lambda _: "y")
@@ -175,14 +175,14 @@ class TestRunAnsiblePlaybook:
         monkeypatch.setattr("devops_bot.tools.ansible.subprocess.run", fake_run)
 
         try:
-            run_ansible_playbook("ansible/playbooks/hello-control.yaml")
+            ansible_run_playbook("ansible/playbooks/hello-control.yaml")
         finally:
             reset_active_run_history(token)
 
         event_kinds = [event.kind for event in run_history.session.events]
         assert "playbook_execution_succeeded" in event_kinds
 
-    def test_run_ansible_playbook_failure_records_run_history(
+    def test_ansible_run_playbook_failure_records_run_history(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.setattr("builtins.input", lambda _: "y")
@@ -204,7 +204,7 @@ class TestRunAnsiblePlaybook:
                 RuntimeError,
                 match=r"inventory parse failed[\s\S]+host unreachable",
             ):
-                run_ansible_playbook("ansible/playbooks/hello-control.yaml")
+                ansible_run_playbook("ansible/playbooks/hello-control.yaml")
         finally:
             reset_active_run_history(token)
 
@@ -217,8 +217,8 @@ class TestRunAnsiblePlaybook:
 
 
 class TestGetAnsiblePlaybookRegistry:
-    def test_get_ansible_playbook_registry(self):
-        registry = get_ansible_playbook_registry()
+    def test_ansible_list_playbooks(self):
+        registry = ansible_list_playbooks()
 
         assert isinstance(registry, list)
         assert len(registry) > 0
@@ -234,12 +234,12 @@ class TestGetAnsiblePlaybookRegistry:
         assert registry_by_path["ansible/playbooks/hello-cluster.yaml"]["name"] == "hello-cluster"
         assert registry_by_path["ansible/playbooks/hello-cluster.yaml"]["target"] == "cluster"
 
-    def test_get_ansible_playbook_registry_records_run_history(self) -> None:
+    def test_ansible_list_playbooks_records_run_history(self) -> None:
         run_history = RunHistory(prompt="inspect registry")
         token = set_active_run_history(run_history)
 
         try:
-            get_ansible_playbook_registry()
+            ansible_list_playbooks()
         finally:
             reset_active_run_history(token)
 
@@ -247,7 +247,7 @@ class TestGetAnsiblePlaybookRegistry:
 
 
 class TestGetAnsibleInventoryGroups:
-    def test_get_ansible_inventory_groups(self):
-        groups = get_ansible_inventory_groups()
+    def test_ansible_list_inventory_groups(self):
+        groups = ansible_list_inventory_groups()
 
         assert groups == ["cluster", "control"]

--- a/tests/tools/test_git.py
+++ b/tests/tools/test_git.py
@@ -7,11 +7,11 @@ from pathlib import Path
 import pytest
 
 from devops_bot.tools import (
-    create_git_branch,
-    create_git_commit,
+    git_create_branch,
+    git_create_commit,
+    git_list_commits,
     git_push,
     git_status,
-    list_git_commits,
 )
 
 
@@ -72,31 +72,31 @@ class TestGitStatus:
 
 
 class TestListGitCommits:
-    def test_list_git_commits(self, git_repo: Path):
+    def test_git_list_commits(self, git_repo: Path):
         with _chdir(git_repo):
-            result = list_git_commits(limit=5)
+            result = git_list_commits(limit=5)
 
         assert result.endswith(" Initial commit")
 
-    def test_list_git_commits_rejects_invalid_limit(self):
+    def test_git_list_commits_rejects_invalid_limit(self):
         with pytest.raises(ValueError):
-            list_git_commits(limit=0)
+            git_list_commits(limit=0)
 
 
 class TestCreateGitCommit:
-    def test_create_git_commit_with_staging(self, git_repo: Path):
+    def test_git_create_commit_with_staging(self, git_repo: Path):
         (git_repo / "playbook.yml").write_text("---\n- hosts: all\n", encoding="utf-8")
 
         with _chdir(git_repo):
-            result = create_git_commit("Add git tools")
+            result = git_create_commit("Add git tools")
 
         assert result.endswith(" Add git tools")
         assert (git_repo / "playbook.yml").exists()
 
     @pytest.mark.parametrize("message", ["   ", ""])
-    def test_create_git_commit_rejects_empty_message(self, message: str):
+    def test_git_create_commit_rejects_empty_message(self, message: str):
         with pytest.raises(ValueError):
-            create_git_commit(message)
+            git_create_commit(message)
 
 
 class TestGitPush:
@@ -250,7 +250,7 @@ class TestGitPush:
 
 
 class TestCreateGitBranch:
-    def test_create_git_branch_from_local_base_branch(self, git_repo: Path):
+    def test_git_create_branch_from_local_base_branch(self, git_repo: Path):
         with _chdir(git_repo):
             subprocess.run(
                 ["git", "branch", "local-base"],
@@ -260,7 +260,7 @@ class TestCreateGitBranch:
                 text=True,
             )
 
-            result = create_git_branch("feature/test", base_ref="local-base")
+            result = git_create_branch("feature/test", base_ref="local-base")
             current_branch = subprocess.run(
                 ["git", "rev-parse", "--abbrev-ref", "HEAD"],
                 check=True,
@@ -272,7 +272,7 @@ class TestCreateGitBranch:
         assert result == "Created and switched to feature/test from local-base"
         assert current_branch == "feature/test"
 
-    def test_create_git_branch_noops_when_already_on_branch(self, git_repo: Path):
+    def test_git_create_branch_noops_when_already_on_branch(self, git_repo: Path):
         with _chdir(git_repo):
             subprocess.run(
                 ["git", "checkout", "-b", "feature/test"],
@@ -282,7 +282,7 @@ class TestCreateGitBranch:
                 text=True,
             )
 
-            result = create_git_branch("feature/test")
+            result = git_create_branch("feature/test")
             current_branch = subprocess.run(
                 ["git", "rev-parse", "--abbrev-ref", "HEAD"],
                 check=True,
@@ -294,7 +294,7 @@ class TestCreateGitBranch:
         assert result == "Already on feature/test"
         assert current_branch == "feature/test"
 
-    def test_create_git_branch_uses_default_base_ref(self, git_repo: Path):
+    def test_git_create_branch_uses_default_base_ref(self, git_repo: Path):
         with _chdir(git_repo):
             subprocess.run(
                 ["git", "branch", "origin/main"],
@@ -304,7 +304,7 @@ class TestCreateGitBranch:
                 text=True,
             )
 
-            result = create_git_branch("feature/test")
+            result = git_create_branch("feature/test")
             current_branch = subprocess.run(
                 ["git", "rev-parse", "--abbrev-ref", "HEAD"],
                 check=True,
@@ -316,7 +316,7 @@ class TestCreateGitBranch:
         assert result == "Created and switched to feature/test from origin/main"
         assert current_branch == "feature/test"
 
-    def test_create_git_branch_uses_explicit_base_ref(self, git_repo: Path):
+    def test_git_create_branch_uses_explicit_base_ref(self, git_repo: Path):
         with _chdir(git_repo):
             subprocess.run(
                 ["git", "branch", "origin/release"],
@@ -326,7 +326,7 @@ class TestCreateGitBranch:
                 text=True,
             )
 
-            result = create_git_branch("feature/test", base_ref="origin/release")
+            result = git_create_branch("feature/test", base_ref="origin/release")
             current_branch = subprocess.run(
                 ["git", "rev-parse", "--abbrev-ref", "HEAD"],
                 check=True,
@@ -339,11 +339,11 @@ class TestCreateGitBranch:
         assert current_branch == "feature/test"
 
     @pytest.mark.parametrize("branch_name", ["", "   "])
-    def test_create_git_branch_rejects_empty_branch_name(self, branch_name: str):
+    def test_git_create_branch_rejects_empty_branch_name(self, branch_name: str):
         with pytest.raises(ValueError):
-            create_git_branch(branch_name)
+            git_create_branch(branch_name)
 
     @pytest.mark.parametrize("base_ref", ["", "   "])
-    def test_create_git_branch_rejects_empty_base_ref(self, base_ref: str):
+    def test_git_create_branch_rejects_empty_base_ref(self, base_ref: str):
         with pytest.raises(ValueError):
-            create_git_branch("feature/test", base_ref=base_ref)
+            git_create_branch("feature/test", base_ref=base_ref)


### PR DESCRIPTION
## Summary

Renames the exposed Ansible and Git tool functions so their names start with the domain, improving consistency for agent tool selection and repo maintenance.

## Changes

- Updated Ansible tool names to `ansible_list_playbooks`, `ansible_run_playbook`, `ansible_create_playbook`, `ansible_edit_playbook`, and `ansible_list_inventory_groups`.
- Updated Git tool names to `git_list_commits`, `git_create_commit`, and `git_create_branch`, while keeping existing matching names like `git_status` and `git_push`.
- Updated orchestrator prompts, tool wiring, exports, generator tools, and affected tests.

## Validation

- [x] `uv run pre-commit run --all-files`
- [x] `uv run mypy`
- [x] `uv run pytest --subprocess-vcr=record`

## Infra Notes

- Deployment, rollout, or operator follow-up: None.
- Secrets, credentials, or permissions touched: None.
- Ansible, CI, or agent behavior impact: Agent-visible tool names change; tool behavior stays the same.

## Risks

- Known tradeoffs: Any external prompt or caller using the old tool names must switch to the new names.
- Follow-up work: None.
