### PR TITLE
Add justfile for local workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,14 +94,13 @@ Human-readable talk generation is intentionally deferred. This first pass writes
 
 ```bash
 # install Python and Node test dependencies
-uv sync --frozen --all-groups
-npm install
+just install
 
 # run tests
-make test
+just test
 
 # run only Git HTTP integration tests
-make test-git-http
+just test-git-http
 
 # create key for cluster nodes
 ssh-keygen -t ed25519
@@ -131,10 +130,10 @@ instead of recorded subprocess fixtures.
 
 Use `subprocess-vcr` for subprocess-heavy paths that are harder to make portable
 across developer machines. The Ansible execution coverage currently follows that
-pattern, and `make test` records those fixtures while pytest replays them by default.
+pattern, and `just test` records those fixtures while pytest replays them by default.
 
 Git HTTP integration tests use `git-http-mock-server`, which shells out to the system `git`
-installation. Run `npm install` before executing `make test-git-http`.
+installation. Run `just install` before executing `just test-git-http`.
 
 ## Setup
 

--- a/conductor.json
+++ b/conductor.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "setup": "./scripts/setup-dev.sh",
-    "run": "make test"
+    "run": "just test"
   },
   "runScriptMode": "nonconcurrent"
 }

--- a/justfile
+++ b/justfile
@@ -1,0 +1,54 @@
+default:
+    @just --list
+
+# Show available recipes.
+help:
+    @just --list
+
+# Install requirements.
+install:
+    uv sync --all-groups
+    npm install
+
+# Install the git pre-commit hook.
+install-pre-commit:
+    uv run pre-commit install
+
+# Run the agent.
+run:
+    uv run devops-agent
+
+# Run lint checks.
+lint:
+    uv run ruff check .
+
+# Format code and auto-fix simple issues.
+format:
+    uv run ruff check --fix .
+    uv run ruff format .
+
+# Run mypy.
+typecheck:
+    uv run mypy
+
+# Run tests.
+test:
+    uv run pytest --subprocess-vcr=record
+
+# Run git HTTP integration tests.
+test-git-http:
+    uv run pytest -m git_http_integration
+
+# Run local CI checks.
+check:
+    uv run pre-commit run --all-files
+    uv run mypy
+    uv run pytest --subprocess-vcr=record
+
+# Open an ipython shell with the dependency environment loaded.
+shell:
+    uv run ipython --ipython-dir=.ipython
+
+# Run the CLI.
+cli:
+    uv run devops-agent --help

--- a/scripts/setup-dev.sh
+++ b/scripts/setup-dev.sh
@@ -26,4 +26,8 @@ if [[ ! -f "$TARGET" ]]; then
   echo "wrote $ROOT/$TARGET from $SOURCE (mode 600)"
 fi
 
-make install
+if command -v just >/dev/null 2>&1; then
+  just install
+else
+  make install
+fi


### PR DESCRIPTION
## Summary

Add a Justfile for local MacBook development while keeping the existing Makefile available for current workflows and automation.

## Changes

- Added a `justfile` with recipes matching the Makefile local workflow targets.
- Updated Conductor and README commands to prefer `just` for install and test workflows.
- Updated `scripts/setup-dev.sh` to use `just install` when available and fall back to `make install` otherwise.

## Validation

- [x] `uv run pre-commit run --all-files`
- [x] `uv run mypy`
- [x] `uv run pytest --subprocess-vcr=record`

## Infra Notes

- Deployment, rollout, or operator follow-up: none.
- Secrets, credentials, or permissions touched: none.
- Ansible, CI, or agent behavior impact: no CI or Ansible changes; local Conductor run command now uses `just test`.

## Risks

- Known tradeoffs: developers running Conductor locally need `just` installed, while setup retains a Makefile fallback for install.
- Follow-up work: none.