### PR TITLE
Update Django runner plan for Strands sessions

### DIFF
--- a/docs/django-agent-runner-plan.md
+++ b/docs/django-agent-runner-plan.md
@@ -8,21 +8,39 @@ The agent currently runs from the command line as a single synchronous workflow:
 CLI prompt -> OrchestratorAgent.run(prompt) -> synchronous tools -> final CLI response
 ```
 
+The CLI now also supports optional Strands session storage. A run can choose a
+stable Strands `session_id`, and the existing run-history path records the
+configured session details when storage is enabled. Reusing that `session_id`
+lets the agent load prior messages and state through the Strands session
+manager.
+
 The tool layer includes blocking subprocess work, including Ansible and Git commands. It also
 contains terminal-centric interactions such as `input()` approval prompts and `print()` previews
 for generated or edited playbooks. That works for the CLI, but it does not map cleanly to web or
 chat channels where requests need to return quickly and user approval may happen later.
+
+The important split for Django is:
+
+- Strands session storage owns model/session continuity.
+- Django owns product workflow state, approvals, locks, job visibility, and UI.
+- JSONL run history remains a compact audit artifact, not the primary resume mechanism.
 
 ## Target Direction
 
 Django should become the service framework around the existing agent package:
 
 ```text
-Django web chat -> persisted workflow/job -> Celery worker -> existing agent/tools
+Django web chat
+  -> AgentWorkflow(session_id, state)
+  -> AgentJob
+  -> Celery worker
+  -> OrchestratorAgent(session_id=workflow.session_id)
+  -> existing agent/tools
 ```
 
-Django owns the web UI, persisted state, approval UI, and job visibility. Celery owns long-running
-execution. The existing `devops_bot` CLI and agent/tool modules remain the core execution path.
+Django owns the web UI, persisted workflow state, approval UI, locking, and job visibility.
+Strands owns persisted agent messages and state. Celery owns long-running execution. The existing
+`devops_bot` CLI and agent/tool modules remain the core execution path.
 
 ## First Slice
 
@@ -33,6 +51,9 @@ The first implementation slice should lock these choices:
 - Celery + Redis for background jobs.
 - Local-only no-login web UI.
 - Existing CLI remains supported.
+- Persist one Strands `session_id` per workflow.
+- Resume continuation jobs by reusing the same Strands `session_id`.
+- Use the existing S3-compatible Strands session storage path first.
 - No Slack or WhatsApp in the first slice.
 - No git worktree parallelism in the first slice.
 
@@ -48,13 +69,22 @@ POST prompt
   -> return/render job page
 
 Celery worker
-  -> runs OrchestratorAgent.run(prompt)
+  -> runs OrchestratorAgent(session_id=workflow.session_id).run(prompt)
   -> records events/state
   -> marks job completed, failed, or waiting_for_approval
 ```
 
 Synchronous `subprocess.run(...)` can remain inside tools for now because that work runs in Celery,
 not in the Django request path.
+
+Continuation jobs should not reconstruct the model transcript themselves. They should reuse the
+workflow's Strands `session_id` and pass a compact continuation prompt or control message that
+identifies the approved pending action. This gives a restartable process-level workflow while
+letting Strands reload the prior agent context.
+
+This is still a new invocation, not Python call-stack suspension. Any approval-required tool path
+must stop cleanly, persist the approval request, and let the next Celery job continue using the
+same session.
 
 ## State Model
 
@@ -65,14 +95,25 @@ The initial durable concepts should be:
 - `AgentEvent`.
 - `PendingApproval`.
 
+`AgentWorkflow` should include:
+
+- `session_id`: the stable Strands session ID used for all jobs in the workflow.
+- `status`: the workflow state.
+- `initial_prompt`: the user's original request.
+- Optional session metadata such as backend and storage prefix for debugging.
+
+`AgentJob` should include the workflow, attempt/sequence number, job kind, submitted prompt or
+continuation payload, Celery task ID, timestamps, and terminal result details.
+
 The top-level naming decision is still open. Candidate names:
 
 - `AgentWorkflow`
 - `AgentRun`
 - `AgentSession`
 
-Recommendation: use `AgentWorkflow`, because one workflow can include multiple jobs when an
-approval continuation is needed.
+Recommendation: use `AgentWorkflow`, because one workflow can include multiple jobs and one or more
+Strands sessions. Avoid using `AgentSession` for the top-level Django model unless the product
+semantics truly match Strands sessions; otherwise the name will be overloaded.
 
 ## Approval Model
 
@@ -88,11 +129,40 @@ worker reaches approval-required action
 user clicks approve
   -> mark approval approved
   -> create continuation job
-  -> Celery resumes from persisted workflow context
+  -> Celery re-invokes OrchestratorAgent with the same Strands session_id
+  -> approved action continues through the tool approval gate
 ```
 
-The continuation should use saved workflow context plus the approved action. This gives the product
-behavior of pause and resume without relying on a Celery worker process staying blocked in memory.
+The continuation should use the workflow row, the approved action payload, and the stable Strands
+session ID. This gives the product behavior of pause and resume without relying on a Celery worker
+process staying blocked in memory.
+
+The approval tool path should become non-terminal. Instead of `input()`, it should call an approval
+service that can:
+
+- Return approved immediately when the matching `PendingApproval` has already been approved.
+- Persist a new `PendingApproval` and raise a controlled pause signal when approval is needed.
+- Return declined or raise a controlled denial when the user rejects the approval.
+
+## State Machine Shape
+
+The Django side should have an explicit state machine, even if the first implementation is a small
+model/service layer instead of a third-party workflow engine.
+
+Initial workflow states:
+
+```text
+queued -> running -> completed
+queued -> running -> failed
+queued -> running -> waiting_for_approval -> queued -> running -> completed
+queued -> running -> waiting_for_approval -> failed
+queued -> canceled
+waiting_for_approval -> canceled
+```
+
+State transitions should be the only place that creates continuation jobs, records approval
+decisions, and releases or acquires the single-active-workflow lock. If this grows beyond a few
+model methods, choose a lightweight Django state-machine library before adding more ad hoc flags.
 
 ## Concurrency Constraint
 
@@ -118,6 +188,33 @@ This constraint is important because:
 - Current tools can run git commands.
 - Current tools can run Ansible against shared hosts.
 - One workspace means concurrent workflows can interfere with each other.
+- Strands session storage preserves agent context, but it does not isolate filesystem or
+  infrastructure side effects.
+
+## Session Storage Path
+
+For the first Django slice, use the existing Strands S3-compatible session manager as the canonical
+agent session store. Django should generate and persist the `session_id` when the workflow is
+created, pass it into every `OrchestratorAgent` invocation, and expose the session ID on the
+workflow detail page for debugging.
+
+Django should not need to store full model transcripts in relational tables for the first slice.
+Relational state should cover indexable product data: workflow status, jobs, approvals, events,
+created timestamps, final summaries, and error details.
+
+For future multi-session agents, add a child model such as `WorkflowAgentSession` only when needed:
+
+- `workflow`
+- `agent_role`
+- `session_id`
+- `backend`
+- `storage_prefix`
+- `status`
+
+That keeps the first slice simple while leaving room for multiple coordinated agents later. A more
+robust session store is only needed when the product needs indexed session metadata, per-agent
+session lifecycle management, or cross-workflow session queries beyond what the Strands object store
+provides.
 
 ## Future Worktree-Based Parallelism
 
@@ -131,6 +228,7 @@ Important future requirements:
 
 - Allocate a worktree per workflow.
 - Persist the worktree path on the workflow.
+- Keep Strands session IDs tied to the workflow, not the worktree path.
 - Run agent/tools with that worktree as the current working directory.
 - Add a cleanup and retention policy.
 - Add locking for shared remote targets, because worktrees isolate files but not infrastructure.
@@ -147,12 +245,14 @@ Important future requirements:
 - No streaming subprocess output unless it falls out naturally from event polling.
 - No redesign of the agent's core orchestration prompt beyond what is needed for persisted
   approvals.
+- No custom multi-agent session store unless the single-session Strands workflow proves too limited.
 
 ## Open Naming Decision
 
 The top-level workflow name is not fully decided yet. Use `AgentWorkflow` as the recommended
 placeholder in the first implementation because it describes the unit that can span an initial job,
-a waiting approval, and one or more continuation jobs.
+a waiting approval, and one or more continuation jobs. Store the Strands identifier as
+`session_id` on that model.
 
 The final naming decision should be made before adding Django models so migrations do not churn.
 
@@ -173,3 +273,5 @@ No test suite is required unless implementation code changes too.
   placeholder.
 - The first implementation must serialize active workflows, even though git worktrees are expected
   to unlock parallelism later.
+- Strands session storage can reload agent context for a restarted job, but Django still needs a
+  workflow state machine for approvals, locking, and UI state.


### PR DESCRIPTION
## Summary

Updates the Django agent runner plan for the Strands session storage workflow and restartable continuation path.

## Changes

- Documented stable Strands `session_id` ownership by `AgentWorkflow`.
- Clarified Django vs Strands responsibilities for workflow state, approvals, locks, jobs, and model context.
- Added an explicit state machine shape plus a future `WorkflowAgentSession` path for multi-session agents.

## Validation

- [x] `git diff --check`
- [ ] `uv run pre-commit run --all-files` (not run; doc-only planning change)
- [ ] `uv run mypy` (not run manually; mypy passed in the commit hook)
- [ ] `uv run pytest --subprocess-vcr=record` (not run; doc-only planning change)

## Infra Notes

- Deployment, rollout, or operator follow-up: None; planning doc only.
- Secrets, credentials, or permissions touched: None.
- Ansible, CI, or agent behavior impact: No runtime impact; future Django runner plan now accounts for Strands session resume semantics.

## Risks

- Known tradeoffs: Assumes the existing Strands S3-compatible store is sufficient for the first Django slice.
- Follow-up work: Implement Django models, state transitions, and the non-terminal approval service when building the runner.