### PR TITLE
Add KWOK integration tests

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -38,6 +38,22 @@ jobs:
       - name: Install Node dependencies
         run: npm ci
 
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.16.1
+
+      - name: Set up kubectl
+        uses: azure/setup-kubectl@v4
+        with:
+          version: v1.33.0
+
+      - name: Set up kwokctl
+        uses: kubernetes-sigs/kwok@v0.7.0
+        with:
+          command: kwokctl
+          kwok-version: v0.7.0
+
       - name: Lint
         run: uv run ruff check .
 
@@ -46,3 +62,5 @@ jobs:
 
       - name: Test
         run: uv run pytest --subprocess-vcr=record
+        env:
+          KWOK_KUBE_VERSION: v1.33.0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@
 
 - Python tooling is managed with `uv`. Install dependencies with `uv sync --frozen --all-groups`.
 - Git HTTP integration tests also require Node dependencies from `package.json`. Install them with `npm install`.
+- Helm/Kubernetes integration tests use KWOK with local Docker, Helm, kubectl, and kwokctl. `./scripts/setup-dev.sh` installs KWOK for local development; CI installs the pinned tool versions directly.
 - The main validation commands in this repo are:
   - `make check`
   - `make test`
@@ -40,6 +41,7 @@
 - If the HTTP client is not VCR-interceptable, keep the networked wrapper deterministic with local unit tests at the library boundary instead of forcing live HTTP into the suite.
 - Pytest defaults to replay mode through `addopts`, and `make test` records fixtures intentionally for the subprocess-vcr-backed cases.
 - Use the `git_http_integration` marker for Git flows that need a realistic remote without hitting an external host.
+- Use the `kwok_integration` marker for Helm/Kubernetes flows that need real Kubernetes API objects without touching the live k3s cluster. Prefer KWOK-backed local coverage over live remote-cluster tests for these tool wrappers.
 - Keep unit tests focused on command construction, argument validation, serialization shape, and error handling for remote-capable tools.
 - When adding structured tool outputs, add typing that reflects the actual serialized shape exposed to the model runtime.
 - If a remote workflow cannot be covered in automated tests, add a short manual verification note to the PR description.

--- a/README.md
+++ b/README.md
@@ -212,18 +212,22 @@ these patterns:
   history records.
 - Local filesystem and subprocess doubles for lightweight tool behavior, such
   as temp charts, temp repos, and monkeypatched command runners.
-- `subprocess-vcr` for subprocess-heavy paths that are harder to make portable
-  across developer machines. The Ansible execution coverage follows that
-  pattern, and `make test` records those fixtures while pytest replays them by
-  default.
-- `pytest-vcr` for HTTP tool tests where the client is compatible with VCR
+- [`subprocess-vcr`](https://pypi.org/project/subprocess-vcr/) for
+  subprocess-heavy paths that are harder to make portable across developer
+  machines. The Ansible execution coverage follows that pattern, and
+  `make test` records those fixtures while pytest replays them by default.
+- [`pytest-vcr`](https://pypi.org/project/pytest-vcr/) for HTTP tool tests where
+  the client is compatible with VCR
   interception.
-- Local Git HTTP integration tests against `git-http-mock-server`, which shells
-  out to the system `git` and avoids external Git hosts.
-- KWOK-backed Helm/Kubernetes integration tests that create a local Docker-backed
-  Kubernetes API server, seed fake schedulable nodes, and exercise real
-  `helm`/`kubectl` subprocesses against real API objects without touching the
-  live k3s cluster.
+- Local Git HTTP integration tests against
+  [`git-http-mock-server`](https://www.npmjs.com/package/git-http-mock-server),
+  which shells out to the system `git` and avoids external Git hosts.
+- [`KWOK`](https://kwok.sigs.k8s.io/)-backed
+  [`Helm`](https://helm.sh/)/
+  [`kubectl`](https://kubernetes.io/docs/reference/kubectl/) integration tests
+  that create a local [`Docker`](https://www.docker.com/)-backed Kubernetes API
+  server, seed fake schedulable nodes, and exercise real `helm`/`kubectl`
+  subprocesses against real API objects without touching the live k3s cluster.
 
 Run `make test` for the default test suite and `make check` for the local CI
 path. Run `make test-git-http` when you only want the Git HTTP integration
@@ -234,5 +238,6 @@ ensures KWOK is available for the Kubernetes integration tests.
 
 `./scripts/setup-dev.sh` creates a local `.env` only when one does not already exist. In a linked
 worktree, it prefers copying the main worktree's `.env`; otherwise it falls back to `.env.example`.
-It also installs KWOK with Homebrew when available, or falls back to pinned
-release binaries for `kwok` and `kwokctl`.
+It also installs [KWOK](https://kwok.sigs.k8s.io/) with
+[Homebrew](https://brew.sh/) when available, or falls back to pinned release
+binaries for `kwok` and `kwokctl`.

--- a/README.md
+++ b/README.md
@@ -203,18 +203,36 @@ uv tool install ansible-core --with ansible
 
 ## Testing
 
-Prefer real local test environments when they are cheap to stand up. In this repo,
-the Git tool tests run against temp repositories and the local HTTP mock server
-instead of recorded subprocess fixtures.
+Prefer real local test environments when they are cheap to stand up, and keep
+live remote systems out of the default suite. The test suite currently uses
+these patterns:
 
-Use `subprocess-vcr` for subprocess-heavy paths that are harder to make portable
-across developer machines. The Ansible execution coverage currently follows that
-pattern, and `just test` records those fixtures while pytest replays them by default.
+- Pure unit tests for deterministic behavior such as command construction,
+  validation, error handling, serialization shape, prompt routing, and run
+  history records.
+- Local filesystem and subprocess doubles for lightweight tool behavior, such
+  as temp charts, temp repos, and monkeypatched command runners.
+- `subprocess-vcr` for subprocess-heavy paths that are harder to make portable
+  across developer machines. The Ansible execution coverage follows that
+  pattern, and `make test` records those fixtures while pytest replays them by
+  default.
+- `pytest-vcr` for HTTP tool tests where the client is compatible with VCR
+  interception.
+- Local Git HTTP integration tests against `git-http-mock-server`, which shells
+  out to the system `git` and avoids external Git hosts.
+- KWOK-backed Helm/Kubernetes integration tests that create a local Docker-backed
+  Kubernetes API server, seed fake schedulable nodes, and exercise real
+  `helm`/`kubectl` subprocesses against real API objects without touching the
+  live k3s cluster.
 
-Git HTTP integration tests use `git-http-mock-server`, which shells out to the system `git`
-installation. Run `just install` before executing `just test-git-http`.
+Run `make test` for the default test suite and `make check` for the local CI
+path. Run `make test-git-http` when you only want the Git HTTP integration
+tests. `./scripts/setup-dev.sh` installs the Python and Node dependencies and
+ensures KWOK is available for the Kubernetes integration tests.
 
 ## Setup
 
 `./scripts/setup-dev.sh` creates a local `.env` only when one does not already exist. In a linked
 worktree, it prefers copying the main worktree's `.env`; otherwise it falls back to `.env.example`.
+It also installs KWOK with Homebrew when available, or falls back to pinned
+release binaries for `kwok` and `kwokctl`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ addopts = "--subprocess-vcr=replay"
 env_files = [".env.example"]
 markers = [
     "git_http_integration: tests that require the git-http-mock-server Node dependency",
+    "kwok_integration: tests that require a local KWOK cluster and real helm/kubectl subprocesses",
     "subprocess_vcr: record and replay subprocess output",
     "vcr: tests that record and replay HTTP traffic",
 ]

--- a/scripts/setup-dev.sh
+++ b/scripts/setup-dev.sh
@@ -6,9 +6,69 @@ cd "$ROOT"
 
 EXAMPLE=".env.example"
 TARGET=".env"
+KWOK_VERSION="${KWOK_VERSION:-v0.7.0}"
+KWOK_INSTALL_DIR="${KWOK_INSTALL_DIR:-$HOME/.local/bin}"
 GIT_COMMON_DIR="$(git rev-parse --git-common-dir)"
 MAIN_WORKTREE="$(cd "$GIT_COMMON_DIR/.." && pwd)"
 MAIN_ENV="$MAIN_WORKTREE/$TARGET"
+
+install_kwok_binary() {
+  local binary="$1"
+  local os="$2"
+  local arch="$3"
+  local destination="$KWOK_INSTALL_DIR/$binary"
+
+  mkdir -p "$KWOK_INSTALL_DIR"
+  curl -fsSL \
+    "https://github.com/kubernetes-sigs/kwok/releases/download/${KWOK_VERSION}/${binary}-${os}-${arch}" \
+    -o "$destination"
+  chmod +x "$destination"
+  echo "installed $binary $KWOK_VERSION to $destination"
+}
+
+ensure_kwok() {
+  if command -v kwok >/dev/null 2>&1 && command -v kwokctl >/dev/null 2>&1; then
+    return
+  fi
+
+  if command -v brew >/dev/null 2>&1; then
+    if brew install kwok; then
+      return
+    fi
+    echo "brew install kwok failed; falling back to pinned release binaries" >&2
+  fi
+
+  local os
+  os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+  local arch
+  case "$(uname -m)" in
+    x86_64 | amd64)
+      arch="amd64"
+      ;;
+    arm64 | aarch64)
+      arch="arm64"
+      ;;
+    *)
+      echo "error: unsupported architecture for KWOK install: $(uname -m)" >&2
+      exit 1
+      ;;
+  esac
+
+  case "$os" in
+    darwin | linux)
+      install_kwok_binary "kwok" "$os" "$arch"
+      install_kwok_binary "kwokctl" "$os" "$arch"
+      ;;
+    *)
+      echo "error: unsupported OS for KWOK install: $os" >&2
+      exit 1
+      ;;
+  esac
+
+  if [[ ":$PATH:" != *":$KWOK_INSTALL_DIR:"* ]]; then
+    echo "note: add $KWOK_INSTALL_DIR to PATH to use kwok and kwokctl from new shells"
+  fi
+}
 
 if [[ ! -f "$EXAMPLE" ]]; then
   echo "error: missing $EXAMPLE (run from repo root or keep this script in scripts/)" >&2
@@ -31,3 +91,5 @@ if command -v just >/dev/null 2>&1; then
 else
   make install
 fi
+
+ensure_kwok

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ import shutil
 import socket
 import subprocess
 import time
+import uuid
 from collections.abc import Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -120,6 +121,167 @@ class GitHttpMockServer:
             encoding="utf-8",
         )
         hook_path.chmod(0o755)
+
+
+@dataclass(frozen=True)
+class KwokCluster:
+    name: str
+    kubeconfig: Path
+
+    @property
+    def env(self) -> dict[str, str]:
+        env = os.environ.copy()
+        env["KUBECONFIG"] = str(self.kubeconfig)
+        env.setdefault("KWOK_KUBE_VERSION", "v1.33.0")
+        return env
+
+
+def _require_kwok_binary(name: str) -> str:
+    path = shutil.which(name)
+    if path is not None:
+        return path
+
+    message = f"{name} is required for kwok_integration tests"
+    if os.environ.get("CI"):
+        pytest.fail(message)
+    pytest.skip(message)
+
+
+def _run_kwok_command(command: list[str], *, env: dict[str, str]) -> None:
+    result = subprocess.run(
+        command,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=env,
+    )
+    if result.returncode != 0:
+        output = "\n".join(part for part in (result.stderr.strip(), result.stdout.strip()) if part)
+        raise RuntimeError(f"KWOK integration command failed: {command}\n{output}")
+
+
+def _wait_for_kubernetes_api(cluster: KwokCluster, timeout_seconds: float = 60.0) -> None:
+    deadline = time.monotonic() + timeout_seconds
+    last_output = ""
+
+    while time.monotonic() < deadline:
+        result = subprocess.run(
+            ["kubectl", "get", "--raw=/readyz"],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env=cluster.env,
+        )
+        if result.returncode == 0 and result.stdout.strip() == "ok":
+            return
+        last_output = "\n".join(
+            part for part in (result.stderr.strip(), result.stdout.strip()) if part
+        )
+        time.sleep(0.5)
+
+    raise RuntimeError(f"Timed out waiting for KWOK Kubernetes API readiness:\n{last_output}")
+
+
+def _seed_kwok_node(cluster: KwokCluster) -> None:
+    node_manifest = cluster.kubeconfig.parent / "kwok-node.yaml"
+    node_manifest.write_text(
+        """apiVersion: v1
+kind: Node
+metadata:
+  annotations:
+    node.alpha.kubernetes.io/ttl: "0"
+    kwok.x-k8s.io/node: fake
+  labels:
+    beta.kubernetes.io/arch: amd64
+    beta.kubernetes.io/os: linux
+    kubernetes.io/arch: amd64
+    kubernetes.io/hostname: kwok-node-0
+    kubernetes.io/os: linux
+    kubernetes.io/role: agent
+    node-role.kubernetes.io/agent: ""
+    type: kwok
+  name: kwok-node-0
+spec:
+  taints:
+    - effect: NoSchedule
+      key: kwok.x-k8s.io/node
+      value: fake
+status:
+  allocatable:
+    cpu: "32"
+    memory: 256Gi
+    pods: "110"
+  capacity:
+    cpu: "32"
+    memory: 256Gi
+    pods: "110"
+  nodeInfo:
+    architecture: amd64
+    bootID: ""
+    containerRuntimeVersion: ""
+    kernelVersion: ""
+    kubeProxyVersion: fake
+    kubeletVersion: fake
+    machineID: ""
+    operatingSystem: linux
+    osImage: ""
+    systemUUID: ""
+  phase: Running
+""",
+        encoding="utf-8",
+    )
+    _run_kwok_command(
+        ["kubectl", "apply", "--validate=false", "-f", str(node_manifest)],
+        env=cluster.env,
+    )
+    _run_kwok_command(
+        ["kubectl", "wait", "--for=condition=Ready", "node/kwok-node-0", "--timeout=60s"],
+        env=cluster.env,
+    )
+
+
+@pytest.fixture(scope="session")
+def kwok_cluster(tmp_path_factory: pytest.TempPathFactory) -> Iterator[KwokCluster]:
+    for binary in ("docker", "kwokctl", "kubectl", "helm"):
+        _require_kwok_binary(binary)
+
+    base_dir = tmp_path_factory.mktemp("kwok")
+    cluster = KwokCluster(
+        name=f"devops-agent-kwok-{uuid.uuid4().hex[:8]}",
+        kubeconfig=base_dir / "kubeconfig.yaml",
+    )
+    env = cluster.env
+
+    try:
+        _run_kwok_command(["docker", "info"], env=env)
+        _run_kwok_command(
+            [
+                "kwokctl",
+                "--name",
+                cluster.name,
+                "create",
+                "cluster",
+                "--runtime=docker",
+                "--kubeconfig",
+                str(cluster.kubeconfig),
+                "--wait=2m",
+            ],
+            env=env,
+        )
+        _wait_for_kubernetes_api(cluster)
+        _seed_kwok_node(cluster)
+        yield cluster
+    finally:
+        subprocess.run(
+            ["kwokctl", "--name", cluster.name, "delete", "cluster"],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env=env,
+        )
 
 
 @pytest.fixture

--- a/tests/tools/test_kubernetes_kwok.py
+++ b/tests/tools/test_kubernetes_kwok.py
@@ -1,0 +1,159 @@
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from devops_bot.tools import (
+    helm_list_releases,
+    helm_status,
+    helm_upgrade_install,
+    kubectl_get,
+    kubectl_rollout_status,
+)
+
+pytestmark = pytest.mark.kwok_integration
+
+
+def _write_fake_chart(chart_path: Path) -> None:
+    templates_path = chart_path / "templates"
+    templates_path.mkdir(parents=True)
+    (chart_path / "Chart.yaml").write_text(
+        "apiVersion: v2\n"
+        "name: kwok-fake-app\n"
+        "description: Test chart for KWOK-backed Kubernetes tool integration.\n"
+        "type: application\n"
+        "version: 0.1.0\n"
+        "appVersion: 1.0.0\n",
+        encoding="utf-8",
+    )
+    (chart_path / "values.yaml").write_text(
+        "replicaCount: 1\n",
+        encoding="utf-8",
+    )
+    (templates_path / "deployment.yaml").write_text(
+        """apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    app.kubernetes.io/name: {{ .Release.Name }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ .Release.Name }}
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: type
+                    operator: In
+                    values:
+                      - kwok
+      tolerations:
+        - key: kwok.x-k8s.io/node
+          operator: Equal
+          value: fake
+          effect: NoSchedule
+      containers:
+        - name: fake-container
+          image: fake-image
+          ports:
+            - name: http
+              containerPort: 80
+""",
+        encoding="utf-8",
+    )
+    (templates_path / "service.yaml").write_text(
+        """apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    app.kubernetes.io/name: {{ .Release.Name }}
+spec:
+  selector:
+    app.kubernetes.io/name: {{ .Release.Name }}
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+""",
+        encoding="utf-8",
+    )
+
+
+def test_helm_and_kubectl_tools_round_trip_against_kwok_objects(
+    kwok_cluster,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    chart_path = tmp_path / "kwok-fake-app"
+    _write_fake_chart(chart_path)
+    release = "kwok-fake-app"
+    namespace = "kwok-tools-test"
+    monkeypatch.setattr("devops_bot.tools.kubernetes.DEFAULT_KUBECONFIG", kwok_cluster.kubeconfig)
+    monkeypatch.setattr("builtins.input", lambda _: "y")
+
+    try:
+        output = helm_upgrade_install(
+            release=release,
+            chart=str(chart_path),
+            namespace=namespace,
+            timeout="60s",
+            create_namespace=True,
+        )
+
+        assert release in output
+        assert "deployed" in output.lower()
+
+        deployments = kubectl_get("deployments", namespace=namespace)
+        assert release in deployments
+
+        rollout = kubectl_rollout_status(
+            f"deployment/{release}",
+            namespace=namespace,
+            timeout="60s",
+        )
+        assert "successfully rolled out" in rollout
+
+        status = json.loads(helm_status(release, namespace=namespace))
+        assert status["name"] == release
+        assert status["namespace"] == namespace
+
+        releases = json.loads(helm_list_releases(namespace=namespace, all_namespaces=False))
+        assert any(item["name"] == release and item["namespace"] == namespace for item in releases)
+    finally:
+        subprocess.run(
+            ["helm", "uninstall", release, "--namespace", namespace],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env=kwok_cluster.env,
+        )
+        subprocess.run(
+            ["kubectl", "delete", "namespace", namespace, "--ignore-not-found=true"],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env=kwok_cluster.env,
+        )
+
+
+def test_kubectl_get_surfaces_real_kwok_api_errors(
+    kwok_cluster,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("devops_bot.tools.kubernetes.DEFAULT_KUBECONFIG", kwok_cluster.kubeconfig)
+
+    with pytest.raises(RuntimeError, match='resource type "definitely-not-a-resource"'):
+        kubectl_get("definitely-not-a-resource")


### PR DESCRIPTION
## Summary

Add KWOK-backed integration coverage for the Helm and Kubernetes tool wrappers so they exercise real Kubernetes API objects through local `helm` and `kubectl` subprocesses without touching the live k3s cluster.

This also updates local setup and CI to install KWOK tooling, and documents the repo's testing strategy across unit tests, subprocess doubles, VCR-backed tests, Git HTTP integration tests, and KWOK-backed Kubernetes integration tests.

## Changes

- Added a `kwok_cluster` pytest fixture that creates a Docker-backed KWOK cluster, waits for API readiness, seeds a fake schedulable node, and tears the cluster down after the session.
- Added `tests/tools/test_kubernetes_kwok.py` covering Helm install/status/list, kubectl get, rollout status, and real API error surfacing against KWOK.
- Registered the `kwok_integration` marker.
- Updated CI to install pinned Helm, kubectl, and kwokctl before the default test step.
- Updated `scripts/setup-dev.sh` to install KWOK locally via Homebrew or pinned release binaries.
- Expanded README testing docs with links to the relevant packages/tools, and updated `AGENTS.md` guidance for future Helm/Kubernetes test work.

## Validation

- [x] `uv run pre-commit run --all-files`
- [x] `uv run mypy`
- [x] `uv run pytest --subprocess-vcr=record`

Also validated through `make check`, which ran the default pytest suite with KWOK integration enabled locally: `130 passed`.

## Infra Notes

- Deployment, rollout, or operator follow-up: No deployment or rollout required. CI now provisions local test tools for KWOK-backed Kubernetes integration coverage.
- Secrets, credentials, or permissions touched: None. The KWOK tests use local Docker and a temp kubeconfig only; they do not use hosted service credentials or the live k3s cluster.
- Ansible, CI, or agent behavior impact: CI installs pinned Helm, kubectl, and kwokctl versions. Agent instructions now prefer KWOK-backed local tests for Helm/Kubernetes tool wrappers that need real API objects.

## Risks

- Known tradeoffs: Default tests now require Docker plus Helm/kubectl/kwokctl for the KWOK integration path. Local runs skip when KWOK dependencies are missing outside CI; CI fails if required tools are absent.
- Follow-up work: None planned.