### PR TITLE
[codex] require docs research for playbook agents

### DIFF
--- a/devops_bot/agents/playbook_editor.py
+++ b/devops_bot/agents/playbook_editor.py
@@ -4,6 +4,7 @@ import yaml
 from pydantic import BaseModel, Field, field_validator
 
 from ..factory import build_agent, build_model
+from ..tools.web import http_get, search_web
 
 SYSTEM_PROMPT = """
 You edit existing Ansible playbooks for this repository.
@@ -60,6 +61,16 @@ Editing Rules:
   slow-booting hosts, follow it with `ansible.builtin.wait_for_connection`,
   refresh facts with `ansible.builtin.setup`, and assert the boot id changed
   before post-reboot desired-state validation.
+
+Research Guidance:
+- When a repair involves module syntax, CLI flags, installation methods,
+  package names, chart values, or version-specific behavior, use `search_web`
+  to find current official documentation, then use `http_get` to read the
+  relevant page before editing.
+- Prefer official upstream/vendor documentation over examples, blog posts, or
+  forum answers.
+- Use `http_get` only for reading documentation.
+- Never use HTTP for mutating system state.
 """
 
 
@@ -82,6 +93,7 @@ class EditAnsiblePlaybookAgent:
         self.agent = build_agent(
             model=build_model(model_id="gpt-5.4"),
             system_prompt=SYSTEM_PROMPT,
+            tools=[search_web, http_get],
         )
 
     def run(

--- a/devops_bot/agents/playbook_generator.py
+++ b/devops_bot/agents/playbook_generator.py
@@ -102,8 +102,13 @@ You generate Ansible playbooks that are safe, idempotent, and verifiable.
 - `cluster`: Raspberry Pi Compute Module 3+ worker nodes
 
 ## Research Guidance
-- Use `search_web` for up-to-date package names, module syntax, or distro-specific behavior.
-- Prefer official upstream/vendor documentation.
+- Before generating install or configuration automation for non-trivial
+  external tools, services, packages, or CLIs, use `search_web` to find current
+  official documentation, then use `http_get` to read the relevant page.
+- Use `search_web` for up-to-date package names, module syntax, CLI flags,
+  installation methods, or distro-specific behavior.
+- Prefer official upstream/vendor documentation over examples, blog posts, or
+  forum answers.
 - Use `http_get` only for reading documentation.
 - Never use HTTP for mutating system state.
 """

--- a/tests/test_generate_playbook.py
+++ b/tests/test_generate_playbook.py
@@ -100,3 +100,11 @@ def test_generator_prompt_defaults_deployments_to_kubernetes() -> None:
     assert "deploy to the cluster with Helm" in SYSTEM_PROMPT
     assert "Do not install application packages" in SYSTEM_PROMPT
     assert "helm upgrade --install" in SYSTEM_PROMPT
+
+
+def test_generator_prompt_requires_official_docs_research() -> None:
+    assert "Before generating install or configuration automation" in SYSTEM_PROMPT
+    assert "use `search_web` to find current\n  official documentation" in SYSTEM_PROMPT
+    assert "use `http_get` to read the relevant page" in SYSTEM_PROMPT
+    assert "CLI flags" in SYSTEM_PROMPT
+    assert "Prefer official upstream/vendor documentation" in SYSTEM_PROMPT

--- a/tests/test_playbook_editing.py
+++ b/tests/test_playbook_editing.py
@@ -1,8 +1,13 @@
 from pathlib import Path
+from typing import Any
 
 import pytest
 
-from devops_bot.agents.playbook_editor import SYSTEM_PROMPT, EditedAnsiblePlaybook
+from devops_bot.agents.playbook_editor import (
+    SYSTEM_PROMPT,
+    EditAnsiblePlaybookAgent,
+    EditedAnsiblePlaybook,
+)
 from devops_bot.history import RunHistory, reset_active_run_history, set_active_run_history
 from devops_bot.tools.playbooks import (
     EditAnsiblePlaybook,
@@ -207,3 +212,26 @@ def test_editor_prompt_preserves_restart_or_reload_after_service_config_changes(
     assert "`restarted`" in SYSTEM_PROMPT
     assert "registered file-change results" in SYSTEM_PROMPT
     assert "Use `started` only as the steady" in SYSTEM_PROMPT
+
+
+def test_editor_prompt_requires_official_docs_research() -> None:
+    assert "When a repair involves module syntax" in SYSTEM_PROMPT
+    assert "use `search_web`\n  to find current official documentation" in SYSTEM_PROMPT
+    assert "use `http_get` to read the\n  relevant page before editing" in SYSTEM_PROMPT
+    assert "Prefer official upstream/vendor documentation" in SYSTEM_PROMPT
+
+
+def test_editor_agent_has_web_research_tools(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_build_agent(**kwargs):
+        captured.update(kwargs)
+        return object()
+
+    monkeypatch.setattr("devops_bot.agents.playbook_editor.build_model", lambda **_: object())
+    monkeypatch.setattr("devops_bot.agents.playbook_editor.build_agent", fake_build_agent)
+
+    EditAnsiblePlaybookAgent()
+
+    tool_names = [tool.tool_name for tool in captured["tools"]]
+    assert tool_names == ["search_web", "http_get"]


### PR DESCRIPTION
## Summary

Requires playbook generation and repair workflows to consult current official documentation for non-trivial install, configuration, and repair work. This makes web research explicit for new playbooks and gives the playbook editor access to the same read-only web research tools used by the generator.

## Changes

- Strengthened the playbook generator research guidance to search official docs and fetch the relevant page before generating non-trivial external tool, service, package, or CLI automation.
- Added `search_web` and `http_get` to the playbook editor agent so repair workflows can research module syntax, CLI flags, install methods, package names, chart values, and version-specific behavior.
- Added tests covering the new prompt requirements and editor web-tool wiring.

## Validation

- [x] `uv run pre-commit run --all-files`
- [x] `uv run mypy`
- [x] `uv run pytest --subprocess-vcr=record`

Additional validation:

- [x] `uv run pytest tests/test_generate_playbook.py tests/test_playbook_editing.py`
- [x] `make test`
- [x] `make check`

## Infra Notes

- Deployment, rollout, or operator follow-up: None; this only changes agent prompt/tool behavior and tests.
- Secrets, credentials, or permissions touched: No secrets or credentials changed. Future playbook repair/generation may use read-only network access through `search_web` and `http_get` when official documentation is needed.
- Ansible, CI, or agent behavior impact: The Ansible playbook editor can now make read-only web research calls before edits; generation guidance is more explicit about official documentation for non-trivial external installs/configuration.

## Risks

- Known tradeoffs: Stronger research guidance may add network dependency and latency during generation or repair when the agent chooses to consult docs. The web tools record compact run-history events rather than full browser/session transcripts.
- Follow-up work: Consider adding a small report field or run-history table for cited documentation URLs if we want PRs or agent responses to summarize exactly which docs informed each generated or repaired playbook.