### PR TITLE
[codex] Improve approval previews and service registry updates

### DIFF
--- a/devops_bot/agents/orchestrator.py
+++ b/devops_bot/agents/orchestrator.py
@@ -86,6 +86,12 @@ Process:
 - Use `service_upsert` only for local repo curation when the requested work
   creates or changes a declared service's identity, ownership, or access path.
   Do not use it to report live health or inferred runtime observations.
+- When local automation or chart work adds a declared service, or changes its
+  owner, namespace, runtime, or user-facing endpoint, call `service_upsert`
+  before finishing even if the user did not explicitly ask to update the
+  registry.
+- Treat the service registry as alphabetically ordered by service name. When
+  updating one entry, preserve that ordering rather than appending in place.
 - Prefer validating the user's requested end state before running remediation
   that mutates remote hosts or cluster state. If the requested state is already
   true, report success instead of continuing through prerequisite or repair

--- a/devops_bot/tools/services.py
+++ b/devops_bot/tools/services.py
@@ -115,10 +115,11 @@ def _load_service_registry(path: Path = SERVICE_REGISTRY_PATH) -> list[ServiceRe
 def _write_service_registry(
     registry: list[ServiceRegistryEntryDict], path: Path = SERVICE_REGISTRY_PATH
 ) -> None:
+    sorted_registry = sorted(registry, key=lambda entry: entry["name"].lower())
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(
         yaml.safe_dump(
-            registry,
+            sorted_registry,
             sort_keys=False,
             allow_unicode=False,
         ),
@@ -202,7 +203,6 @@ def service_upsert(
             break
     else:
         registry.append(serialized)
-        registry.sort(key=lambda entry: entry["name"])
 
     _write_service_registry(registry)
     record_event(

--- a/devops_bot/tui.py
+++ b/devops_bot/tui.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import threading
+from dataclasses import dataclass
 from typing import Protocol, cast
 
 from textual import events
@@ -23,6 +24,13 @@ COMMANDS = {
 PROMPT_MIN_LINES = 1
 PROMPT_MAX_LINES = 5
 PROMPT_CHROME_HEIGHT = 2
+
+
+@dataclass(slots=True)
+class PreviewState:
+    title: str
+    body: str
+    context: dict[str, object]
 
 
 class PromptSubmittingApp(Protocol):
@@ -86,7 +94,13 @@ class TextualAdapter:
             done.set()
 
         def show_prompt() -> None:
-            self._app.push_screen(YesNoScreen(request["prompt"]), callback=handle_result)
+            self._app.push_screen(
+                YesNoScreen(
+                    request["prompt"],
+                    details=self._app._approval_details_for_request(request),
+                ),
+                callback=handle_result,
+            )
 
         self._app.call_from_thread(show_prompt)
         done.wait()
@@ -94,18 +108,46 @@ class TextualAdapter:
 
 
 class YesNoScreen(ModalScreen[bool]):
-    def __init__(self, prompt: str) -> None:
+    BINDINGS = [
+        Binding("y", "approve", "Yes", show=False),
+        Binding("n", "decline", "No", show=False),
+        Binding("escape", "decline", "No", show=False),
+    ]
+
+    def __init__(self, prompt: str, *, details: str | None = None) -> None:
         super().__init__()
         self._prompt = prompt
+        self._details = details
 
     def compose(self) -> ComposeResult:
         yield Label(self._prompt, id="approval-prompt")
+        if self._details is not None:
+            yield TextArea(
+                self._details,
+                id="approval-details",
+                read_only=True,
+                show_cursor=False,
+                soft_wrap=True,
+                highlight_cursor_line=False,
+            )
         with Horizontal(id="approval-actions"):
             yield Button("Yes", id="yes", variant="success")
             yield Button("No", id="no", variant="error")
 
+    def on_mount(self) -> None:
+        if self._details is None:
+            self.query_one("#yes", Button).focus()
+            return
+        self.query_one("#approval-details", TextArea).focus()
+
     def on_button_pressed(self, event: Button.Pressed) -> None:
         self.dismiss(event.button.id == "yes")
+
+    def action_approve(self) -> None:
+        self.dismiss(True)
+
+    def action_decline(self) -> None:
+        self.dismiss(False)
 
 
 class DevopsAgentApp(App[None]):
@@ -141,6 +183,13 @@ class DevopsAgentApp(App[None]):
 
     #approval-prompt {
         padding: 1 2;
+    }
+
+    #approval-details {
+        height: 1fr;
+        min-height: 8;
+        border: solid $accent;
+        margin: 0 2 1 2;
     }
 
     #approval-actions {
@@ -190,6 +239,7 @@ class DevopsAgentApp(App[None]):
         self._adapter: InteractiveAdapter = TextualAdapter(self)
         self._busy = False
         self._chat_history: list[str] = []
+        self._latest_preview: PreviewState | None = None
         self._prompt.focus()
         self._resize_prompt()
         self._hide_command_menu()
@@ -219,6 +269,11 @@ class DevopsAgentApp(App[None]):
             return
 
         if kind == "preview":
+            self._latest_preview = PreviewState(
+                title=event["title"],
+                body=event["body"],
+                context=cast(dict[str, object], event.get("context", {})),
+            )
             self.write_message("system", f"{event['title']}\n{event['body']}")
             return
 
@@ -343,6 +398,23 @@ class DevopsAgentApp(App[None]):
         self._prompt.focus()
         self._prompt.insert(text)
         self._resize_prompt()
+
+    def _approval_details_for_request(self, request: ApprovalRequest) -> str | None:
+        preview = self._latest_preview
+        if preview is None:
+            return None
+
+        preview_path = preview.context.get("path")
+        request_path = request["context"].get("path")
+        prompt = request["prompt"]
+
+        if isinstance(request_path, str) and request_path == preview_path:
+            return f"{preview.title}\n\n{preview.body}"
+        if isinstance(preview_path, str) and preview_path in prompt:
+            return f"{preview.title}\n\n{preview.body}"
+        if "write " in prompt.lower():
+            return f"{preview.title}\n\n{preview.body}"
+        return None
 
 
 def main() -> int:

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -4,7 +4,8 @@ from typing import cast
 from textual.binding import Binding
 from textual.widgets import TextArea
 
-from devops_bot.tui import DevopsAgentApp
+from devops_bot.approval import ApprovalRequest
+from devops_bot.tui import DevopsAgentApp, PreviewState, YesNoScreen
 from devops_bot.workflow import AgentWorkflow
 
 
@@ -197,5 +198,82 @@ def test_tui_submits_multiline_prompt_with_enter() -> None:
             assert workflow.runs == ["deploy\nnginx"]
             assert prompt.text == ""
             assert "you> deploy\nnginx" in chat_log.text
+
+    asyncio.run(run_test())
+
+
+def test_tui_approval_uses_matching_preview_details_for_write_requests() -> None:
+    app = DevopsAgentApp()
+    app._latest_preview = PreviewState(
+        title="Generated preview",
+        body="Path: ansible/playbooks/example.yaml\n\n- hosts: localhost",
+        context={"path": "ansible/playbooks/example.yaml"},
+    )
+    request: ApprovalRequest = {
+        "kind": "confirmation",
+        "prompt": "Write playbook to ansible/playbooks/example.yaml? [y/N]: ",
+        "context": {},
+    }
+
+    details = app._approval_details_for_request(request)
+
+    assert details == (
+        "Generated preview\n\nPath: ansible/playbooks/example.yaml\n\n- hosts: localhost"
+    )
+
+
+def test_tui_approval_ignores_preview_for_non_write_requests() -> None:
+    app = DevopsAgentApp()
+
+    app._latest_preview = PreviewState(
+        title="Generated preview",
+        body="Path: ansible/playbooks/example.yaml\n\n- hosts: localhost",
+        context={"path": "ansible/playbooks/example.yaml"},
+    )
+    request: ApprovalRequest = {
+        "kind": "confirmation",
+        "prompt": "Restart systemd service 'grafana' on this machine? [y/N]: ",
+        "context": {},
+    }
+
+    details = app._approval_details_for_request(request)
+
+    assert details is None
+
+
+def test_tui_approval_preview_is_focusable_and_scrolls() -> None:
+    async def run_test() -> None:
+        app = DevopsAgentApp()
+
+        async with app.run_test() as pilot:
+            long_body = "\n".join(f"line {index}" for index in range(80))
+            app._latest_preview = PreviewState(
+                title="Attachment preview",
+                body=long_body,
+                context={"path": ".context/attachments/image.png"},
+            )
+            request: ApprovalRequest = {
+                "kind": "confirmation",
+                "prompt": "Write file to .context/attachments/image.png? [y/N]: ",
+                "context": {},
+            }
+            screen = YesNoScreen(
+                request["prompt"],
+                details=app._approval_details_for_request(request),
+            )
+
+            app.push_screen(screen)
+            await pilot.pause()
+
+            details = screen.query_one("#approval-details", TextArea)
+            assert app.screen.focused is details
+            assert details.read_only is True
+            assert details.show_cursor is False
+
+            starting_scroll_y = details.scroll_y
+            await pilot.press("pagedown")
+            await pilot.pause()
+
+            assert details.scroll_y > starting_scroll_y
 
     asyncio.run(run_test())

--- a/tests/tools/test_services.py
+++ b/tests/tools/test_services.py
@@ -300,6 +300,58 @@ class TestServiceUpsert:
         assert service_get("grafana")["description"] == "Updated description."
         assert service_get("grafana")["tags"] == ["monitoring", "dashboards"]
 
+    def test_service_upsert_rewrites_registry_in_alphabetical_order(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        registry_path = tmp_path / "services" / "registry.yaml"
+        registry_path.parent.mkdir(parents=True)
+        registry_path.write_text(
+            "- name: zebra\n"
+            "  description: Zebra service.\n"
+            "  runtime: systemd\n"
+            "  location: control\n"
+            "  status: expected\n"
+            "  managed_by: ansible/playbooks/install-zebra.yaml\n"
+            "  endpoints:\n"
+            "    - name: health\n"
+            "      url: http://127.0.0.1:9100/health\n"
+            "  tags:\n"
+            "    - monitoring\n"
+            "- name: alpha\n"
+            "  description: Alpha service.\n"
+            "  runtime: systemd\n"
+            "  location: control\n"
+            "  status: expected\n"
+            "  managed_by: ansible/playbooks/install-alpha.yaml\n"
+            "  endpoints:\n"
+            "    - name: health\n"
+            "      url: http://127.0.0.1:9200/health\n"
+            "  tags:\n"
+            "    - monitoring\n",
+            encoding="utf-8",
+        )
+        monkeypatch.chdir(tmp_path)
+
+        service_upsert(
+            name="zebra",
+            description="Updated zebra service.",
+            runtime="systemd",
+            location="control",
+            status="expected",
+            managed_by="ansible/playbooks/install-zebra.yaml",
+            endpoints=[
+                {
+                    "name": "health",
+                    "url": "http://127.0.0.1:9100/health",
+                }
+            ],
+            tags=["monitoring", "updated"],
+        )
+
+        registry_text = registry_path.read_text(encoding="utf-8")
+        assert registry_text.startswith("- name: alpha\n")
+        assert "endpoints:\n  - name: health\n" in registry_text
+
     def test_service_upsert_rejects_invalid_endpoint_shape(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:


### PR DESCRIPTION
## Summary

Improve the approval modal so write requests show a scrollable preview with keyboard-friendly focus, and keep the service registry automatically updated in alphabetical order. The repo maintenance outcome is more reliable approval review UX and a registry file that stays consistently curated without extra prompting.

## Changes

- Added approval preview state in the TUI, surfaced matching preview content in confirmation dialogs for write requests, and made the modal preview focusable and scrollable with keyboard bindings.
- Added TUI coverage for preview matching, non-write requests, and scroll behavior.
- Changed `service_upsert` to sort the full registry on every write, updated orchestrator guidance so service-creating work updates the registry automatically, and added regression coverage for alphabetical ordering and YAML sequence spacing.

## Validation

- [x] `uv run pre-commit run --all-files`
- [x] `uv run mypy`
- [x] `uv run pytest --subprocess-vcr=record`

## Infra Notes

- Deployment, rollout, or operator follow-up: None for this change.
- Secrets, credentials, or permissions touched: None in repo code; PR creation used existing GitHub access from this checkout.
- Ansible, CI, or agent behavior impact: The Textual approval flow now shows generated write previews directly in the confirmation modal, and the orchestrator now treats declared service registry updates as required follow-up when service metadata changes.

## Risks

- Known tradeoffs: The approval preview matching logic is heuristic and currently keyed off write-style prompts and optional path context.
- Follow-up work: If approval prompts broaden beyond file writes, the preview selection rules may need a more explicit request-to-preview linkage.
