### PR TITLE
[codex] Add simple Langfuse observability for Strands

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,14 @@
 # https://platform.openai.com/api-keys
 OPENAI_API_KEY=your-openai-api-key
 
+# logging and observability
 DEVOPS_AGENT_RUN_HISTORY_ENABLED=true
+LANGFUSE_ENABLED=false
+# LANGFUSE_BASE_URL=https://us.cloud.langfuse.com
+# LANGFUSE_PUBLIC_KEY=pk-lf-your-langfuse-public-key
+# LANGFUSE_SECRET_KEY=sk-lf-your-langfuse-secret-key
+
+# web based interface to agent
 REDIS_URL=redis://127.0.0.1:6379/0
 # DJANGO_SECRET_KEY=change-me
 # DJANGO_ALLOWED_HOSTS=127.0.0.1,localhost

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@
 - When opening a PR, fill out `.github/pull_request_template.md` completely. Do not leave the summary, validation, infra notes, or risks sections as placeholders.
 - Check `justfile` before running validation or local workflows, and prefer its recipes over ad hoc commands when an equivalent recipe exists.
 - Keep control flow top-down and obvious.
+- Prefer the smallest obvious implementation over extensible design. Optimize for readability by a future human maintainer, not reuse.
 - If the design starts to need more than ~2 helpers or ~1 new module, stop and ask first.
 
 ## Tools And Remote Boundaries

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@
 - Check `justfile` before running validation or local workflows, and prefer its recipes over ad hoc commands when an equivalent recipe exists.
 - Keep control flow top-down and obvious.
 - Prefer the smallest obvious implementation over extensible design. Optimize for readability by a future human maintainer, not reuse.
+- When the user provides a working example, follow its structure closely and treat deviations as a mistake unless required by this repo.
 - If the design starts to need more than ~2 helpers or ~1 new module, stop and ask first.
 
 ## Tools And Remote Boundaries

--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ Every playbook metadata header must include:
 
 Set `OPENAI_MODEL=gpt-5.4` by default for stronger reasoning and coding quality. If you need a lower-cost option, use `gpt-5.4-mini`.
 
+### Logging and Langfuse
+
+The agent uses standard Python logging and sets the `strands` logger to `INFO`.
+
+Langfuse tracing is optional. Set `LANGFUSE_ENABLED=true` and provide `LANGFUSE_BASE_URL`, `LANGFUSE_PUBLIC_KEY`, and `LANGFUSE_SECRET_KEY` to initialize the Langfuse client for Strands runs.
+
 ### Example
 
 ```bash

--- a/devops_bot/agents/orchestrator.py
+++ b/devops_bot/agents/orchestrator.py
@@ -1,6 +1,7 @@
 from collections.abc import Iterable
 from pathlib import Path
 from typing import Any
+from uuid import uuid4
 
 from strands import AgentSkills
 from strands.hooks.events import (
@@ -213,9 +214,8 @@ class OrchestratorAgent:
     ) -> None:
         _ = thinking
         self._latest_rationale: str | None = None
-        session_manager = (
-            build_session_manager(session_id=session_id) if session_id is not None else None
-        )
+        session_id = session_id or uuid4().hex
+        session_manager = build_session_manager(session_id=session_id)
         self.agent = build_agent(
             model=build_model(model_id="gpt-5.4"),
             system_prompt=MAIN_SYSTEM_PROMPT,
@@ -242,6 +242,10 @@ class OrchestratorAgent:
             ],
             plugins=[AgentSkills(skills=[SKILLS_DIR], strict=True)],
             session_manager=session_manager,
+            trace_attributes={
+                "session.id": session_id,
+                "gen_ai.conversation.id": session_id,
+            },
         )
         self.agent.add_hook(self._on_before_invocation, BeforeInvocationEvent)
         self.agent.add_hook(self._on_message_added, MessageAddedEvent)

--- a/devops_bot/config.py
+++ b/devops_bot/config.py
@@ -1,10 +1,25 @@
+import logging
+
+from langfuse import get_client
+
 from .secrets import SecretsManager
 
 secret_manager = SecretsManager(path=".env")
 
+# https://strandsagents.com/docs/user-guide/observability-evaluation/logs/
+logging.getLogger("strands").setLevel(logging.INFO)
+logging.basicConfig(
+    format="%(levelname)s | %(name)s | %(message)s",
+    handlers=[logging.StreamHandler()],
+)
+
 OPENAI_API_KEY = secret_manager.get(str, "OPENAI_API_KEY")
 
 RUN_HISTORY_ENABLED = secret_manager.get(bool, "DEVOPS_AGENT_RUN_HISTORY_ENABLED", True)
+
+LANGFUSE_ENABLED = secret_manager.get(bool, "LANGFUSE_ENABLED", False)
+if LANGFUSE_ENABLED:
+    langfuse = get_client()
 
 SESSION_BACKEND = secret_manager.get(str, "DEVOPS_AGENT_SESSION_BACKEND", "none")
 SESSION_S3_BUCKET = secret_manager.get(str, "DEVOPS_AGENT_SESSION_S3_BUCKET", None)

--- a/devops_bot/config.py
+++ b/devops_bot/config.py
@@ -18,8 +18,7 @@ OPENAI_API_KEY = secret_manager.get(str, "OPENAI_API_KEY")
 RUN_HISTORY_ENABLED = secret_manager.get(bool, "DEVOPS_AGENT_RUN_HISTORY_ENABLED", True)
 
 LANGFUSE_ENABLED = secret_manager.get(bool, "LANGFUSE_ENABLED", False)
-if LANGFUSE_ENABLED:
-    langfuse = get_client()
+langfuse = get_client() if LANGFUSE_ENABLED else None
 
 SESSION_BACKEND = secret_manager.get(str, "DEVOPS_AGENT_SESSION_BACKEND", "none")
 SESSION_S3_BUCKET = secret_manager.get(str, "DEVOPS_AGENT_SESSION_S3_BUCKET", None)

--- a/devops_bot/factory.py
+++ b/devops_bot/factory.py
@@ -32,6 +32,7 @@ def build_agent(
     tools: Optional[Sequence[Any]] = None,
     plugins: Optional[Sequence[Plugin]] = None,
     session_manager: SessionManager | None = None,
+    trace_attributes: dict[str, str] | None = None,
 ) -> Agent:
     if tools is None:
         tools = []
@@ -44,4 +45,5 @@ def build_agent(
         tools=list(tools),
         plugins=list(plugins),
         session_manager=session_manager,
+        trace_attributes=trace_attributes,
     )

--- a/devops_bot/main.py
+++ b/devops_bot/main.py
@@ -4,6 +4,7 @@ from uuid import uuid4
 
 from .agents.orchestrator import OrchestratorAgent
 from .approval import ApprovalRequest
+from .config import langfuse
 from .history import (
     RUN_HISTORY_PATH,
     RunHistory,
@@ -86,6 +87,8 @@ def main() -> int:
             run_history.finalize(response)
             _append_run_history(run_history)
     finally:
+        if langfuse is not None:
+            langfuse.flush()
         if token is not None:
             reset_active_run_history(token)
         reset_workflow_runtime(runtime_token)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,12 +8,13 @@ dependencies = [
     "celery[redis]>=5.5.3",
     "ddgs>=9.6.1",
     "django>=5.2.7",
+    "langfuse>=3.9.1",
     "pydantic>=2.12.0",
     "pyyaml>=6.0.3",
     "python-dotenv>=1.1.1",
     "redis>=6.4.0",
     "strands-agents-tools>=0.3.0",
-    "strands-agents[openai]>=1.34.1",
+    "strands-agents[openai,otel]>=1.34.1",
     "textual>=1.0.0",
 ]
 

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -44,6 +44,7 @@ def test_build_agent_passes_session_manager(monkeypatch) -> None:
         "tools": ["tool"],
         "plugins": [],
         "session_manager": session_manager,
+        "trace_attributes": None,
     }
 
 
@@ -72,4 +73,25 @@ def test_build_agent_passes_plugins(monkeypatch) -> None:
         "tools": ["tool"],
         "plugins": [plugin],
         "session_manager": None,
+        "trace_attributes": None,
     }
+
+
+def test_build_agent_passes_trace_attributes(monkeypatch) -> None:
+    captured: dict[str, Any] = {}
+
+    class FakeAgent:
+        def __init__(self, **kwargs: Any) -> None:
+            captured.update(kwargs)
+
+    model = cast(OpenAIModel, object())
+    monkeypatch.setattr(factory_module, "Agent", FakeAgent)
+
+    agent = build_agent(
+        model=model,
+        system_prompt="system",
+        trace_attributes={"session.id": "session-1"},
+    )
+
+    assert isinstance(agent, FakeAgent)
+    assert captured["trace_attributes"] == {"session.id": "session-1"}

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -244,3 +244,35 @@ def test_orchestrator_builds_session_manager_for_session_id(monkeypatch) -> None
     assert orchestrator.agent is fake_agent
     assert captured["session_id"] == "run-123"
     assert captured["build_agent"]["session_manager"] is fake_session_manager
+    assert captured["build_agent"]["trace_attributes"] == {
+        "session.id": "run-123",
+        "gen_ai.conversation.id": "run-123",
+    }
+
+
+def test_orchestrator_generates_session_id_when_missing(monkeypatch) -> None:
+    captured: dict[str, Any] = {}
+    fake_session_manager = object()
+    fake_agent = FakeAgent()
+
+    def fake_build_session_manager(*, session_id: str) -> object:
+        captured["session_id"] = session_id
+        return fake_session_manager
+
+    def fake_build_agent(**kwargs: Any) -> FakeAgent:
+        captured["build_agent"] = kwargs
+        return fake_agent
+
+    monkeypatch.setattr(orchestrator_module, "build_model", lambda model_id: object())
+    monkeypatch.setattr(orchestrator_module, "build_session_manager", fake_build_session_manager)
+    monkeypatch.setattr(orchestrator_module, "build_agent", fake_build_agent)
+
+    orchestrator = OrchestratorAgent()
+
+    assert orchestrator.agent is fake_agent
+    assert captured["session_id"]
+    assert captured["build_agent"]["session_manager"] is fake_session_manager
+    assert captured["build_agent"]["trace_attributes"] == {
+        "session.id": captured["session_id"],
+        "gen_ai.conversation.id": captured["session_id"],
+    }

--- a/uv.lock
+++ b/uv.lock
@@ -163,6 +163,15 @@ wheels = [
 ]
 
 [[package]]
+name = "backoff"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/d7/5bbeb12c44d7c4f2fb5b56abce497eb5ed9f34d85701de869acedd602619/backoff-2.2.1.tar.gz", hash = "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba", size = 17001 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/73/b6e24bd22e6720ca8ee9a85a0c4a2971af8497d8f3193fa05390cbd46e09/backoff-2.2.1-py3-none-any.whl", hash = "sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8", size = 15148 },
+]
+
+[[package]]
 name = "beautifulsoup4"
 version = "4.14.3"
 source = { registry = "https://pypi.org/simple" }
@@ -499,11 +508,12 @@ dependencies = [
     { name = "celery", extra = ["redis"] },
     { name = "ddgs" },
     { name = "django" },
+    { name = "langfuse" },
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
     { name = "redis" },
-    { name = "strands-agents", extra = ["openai"] },
+    { name = "strands-agents", extra = ["openai", "otel"] },
     { name = "strands-agents-tools" },
     { name = "textual" },
 ]
@@ -529,11 +539,12 @@ requires-dist = [
     { name = "celery", extras = ["redis"], specifier = ">=5.5.3" },
     { name = "ddgs", specifier = ">=9.6.1" },
     { name = "django", specifier = ">=5.2.7" },
+    { name = "langfuse", specifier = ">=3.9.1" },
     { name = "pydantic", specifier = ">=2.12.0" },
     { name = "python-dotenv", specifier = ">=1.1.1" },
     { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "redis", specifier = ">=6.4.0" },
-    { name = "strands-agents", extras = ["openai"], specifier = ">=1.34.1" },
+    { name = "strands-agents", extras = ["openai", "otel"], specifier = ">=1.34.1" },
     { name = "strands-agents-tools", specifier = ">=0.3.0" },
     { name = "textual", specifier = ">=1.0.0" },
 ]
@@ -702,6 +713,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/89/76/c615883b7b521ead2944bb3480398cbb07e12b7b4e4d073d3752eb721558/frozenlist-1.8.0-cp314-cp314t-win_amd64.whl", hash = "sha256:06be8f67f39c8b1dc671f5d83aaefd3358ae5cdcf8314552c57e7ed3e6475bdd", size = 49451 },
     { url = "https://files.pythonhosted.org/packages/e0/a3/5982da14e113d07b325230f95060e2169f5311b1017ea8af2a29b374c289/frozenlist-1.8.0-cp314-cp314t-win_arm64.whl", hash = "sha256:102e6314ca4da683dca92e3b1355490fed5f313b768500084fbe6371fddfdb79", size = 42507 },
     { url = "https://files.pythonhosted.org/packages/9a/9a/e35b4a917281c0b8419d4207f4334c8e8c5dbf4f3f5f9ada73958d937dcc/frozenlist-1.8.0-py3-none-any.whl", hash = "sha256:0c18a16eab41e82c295618a77502e17b195883241c563b00f0aa5106fc4eaa0d", size = 13409 },
+]
+
+[[package]]
+name = "googleapis-common-protos"
+version = "1.74.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/20/18/a746c8344152d368a5aac738d4c857012f2c5d1fd2eac7e17b647a7861bd/googleapis_common_protos-1.74.0.tar.gz", hash = "sha256:57971e4eeeba6aad1163c1f0fc88543f965bb49129b8bb55b2b7b26ecab084f1", size = 151254 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/b0/be5d3329badb9230b765de6eea66b73abd5944bdeb5afb3562ddcd80ae84/googleapis_common_protos-1.74.0-py3-none-any.whl", hash = "sha256:702216f78610bb510e3f12ac3cafd281b7ac45cc5d86e90ad87e4d301a3426b5", size = 300743 },
 ]
 
 [[package]]
@@ -947,6 +970,25 @@ wheels = [
 [package.optional-dependencies]
 redis = [
     { name = "redis" },
+]
+
+[[package]]
+name = "langfuse"
+version = "4.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backoff" },
+    { name = "httpx" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-sdk" },
+    { name = "packaging" },
+    { name = "pydantic" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/bd/9b12c9dd3ae1883619b20daa6d60f20a780ce2d25564d9b2168db27cbeb0/langfuse-4.5.1.tar.gz", hash = "sha256:fe8f9219f4101c0921934b0aeb1b45834f8e7d248e5f830b2c89c5b40aea6d83", size = 279735 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2b/63/77bd7220dfd60885a272a851f780b3f83e0f653ee3a852347552c3e24a28/langfuse-4.5.1-py3-none-any.whl", hash = "sha256:5923cafe8289c9e3c53cb6992f4b46ec3132473b9f9eb65eb33ad28e2682db81", size = 479527 },
 ]
 
 [[package]]
@@ -1335,6 +1377,36 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-exporter-otlp-proto-common"
+version = "1.40.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-proto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/51/bc/1559d46557fe6eca0b46c88d4c2676285f1f3be2e8d06bb5d15fbffc814a/opentelemetry_exporter_otlp_proto_common-1.40.0.tar.gz", hash = "sha256:1cbee86a4064790b362a86601ee7934f368b81cd4cc2f2e163902a6e7818a0fa", size = 20416 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/ca/8f122055c97a932311a3f640273f084e738008933503d0c2563cd5d591fc/opentelemetry_exporter_otlp_proto_common-1.40.0-py3-none-any.whl", hash = "sha256:7081ff453835a82417bf38dccf122c827c3cbc94f2079b03bba02a3165f25149", size = 18369 },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-http"
+version = "1.40.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2e/fa/73d50e2c15c56be4d000c98e24221d494674b0cc95524e2a8cb3856d95a4/opentelemetry_exporter_otlp_proto_http-1.40.0.tar.gz", hash = "sha256:db48f5e0f33217588bbc00274a31517ba830da576e59503507c839b38fa0869c", size = 17772 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/3a/8865d6754e61c9fb170cdd530a124a53769ee5f740236064816eb0ca7301/opentelemetry_exporter_otlp_proto_http-1.40.0-py3-none-any.whl", hash = "sha256:a8d1dab28f504c5d96577d6509f80a8150e44e8f45f82cdbe0e34c99ab040069", size = 19960 },
+]
+
+[[package]]
 name = "opentelemetry-instrumentation"
 version = "0.61b0"
 source = { registry = "https://pypi.org/simple" }
@@ -1361,6 +1433,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/12/8f/8dedba66100cda58af057926449a5e58e6c008bec02bc2746c03c3d85dcd/opentelemetry_instrumentation_threading-0.61b0.tar.gz", hash = "sha256:38e0263c692d15a7a458b3fa0286d29290448fa4ac4c63045edac438c6113433", size = 9163 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e8/77/c06d960aede1a014812aa4fafde0ae546d790f46416fbeafa2b32095aae3/opentelemetry_instrumentation_threading-0.61b0-py3-none-any.whl", hash = "sha256:735f4a1dc964202fc8aff475efc12bb64e6566f22dff52d5cb5de864b3fe1a70", size = 9337 },
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "1.40.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4c/77/dd38991db037fdfce45849491cb61de5ab000f49824a00230afb112a4392/opentelemetry_proto-1.40.0.tar.gz", hash = "sha256:03f639ca129ba513f5819810f5b1f42bcb371391405d99c168fe6937c62febcd", size = 45667 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/b2/189b2577dde745b15625b3214302605b1353436219d42b7912e77fa8dc24/opentelemetry_proto-1.40.0-py3-none-any.whl", hash = "sha256:266c4385d88923a23d63e353e9761af0f47a6ed0d486979777fe4de59dc9b25f", size = 72073 },
 ]
 
 [[package]]
@@ -1651,6 +1735,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/ef/3c6ecf8b317aa982f309835e8f96987466123c6e596646d4e6a1dfcd080f/propcache-0.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:990f6b3e2a27d683cb7602ed6c86f15ee6b43b1194736f9baaeb93d0016633b1", size = 46259 },
     { url = "https://files.pythonhosted.org/packages/c4/2d/346e946d4951f37eca1e4f55be0f0174c52cd70720f84029b02f296f4a38/propcache-0.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:ecef2343af4cc68e05131e45024ba34f6095821988a9d0a02aa7c73fcc448aa9", size = 40428 },
     { url = "https://files.pythonhosted.org/packages/5b/5a/bc7b4a4ef808fa59a816c17b20c4bef6884daebbdf627ff2a161da67da19/propcache-0.4.1-py3-none-any.whl", hash = "sha256:af2a6052aeb6cf17d3e46ee169099044fd8224cbaf75c76a2ef596e8163e2237", size = 13305 },
+]
+
+[[package]]
+name = "protobuf"
+version = "6.33.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/70/e908e9c5e52ef7c3a6c7902c9dfbb34c7e29c25d2f81ade3856445fd5c94/protobuf-6.33.6.tar.gz", hash = "sha256:a6768d25248312c297558af96a9f9c929e8c4cee0659cb07e780731095f38135", size = 444531 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/9f/2f509339e89cfa6f6a4c4ff50438db9ca488dec341f7e454adad60150b00/protobuf-6.33.6-cp310-abi3-win32.whl", hash = "sha256:7d29d9b65f8afef196f8334e80d6bc1d5d4adedb449971fefd3723824e6e77d3", size = 425739 },
+    { url = "https://files.pythonhosted.org/packages/76/5d/683efcd4798e0030c1bab27374fd13a89f7c2515fb1f3123efdfaa5eab57/protobuf-6.33.6-cp310-abi3-win_amd64.whl", hash = "sha256:0cd27b587afca21b7cfa59a74dcbd48a50f0a6400cfb59391340ad729d91d326", size = 437089 },
+    { url = "https://files.pythonhosted.org/packages/5c/01/a3c3ed5cd186f39e7880f8303cc51385a198a81469d53d0fdecf1f64d929/protobuf-6.33.6-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:9720e6961b251bde64edfdab7d500725a2af5280f3f4c87e57c0208376aa8c3a", size = 427737 },
+    { url = "https://files.pythonhosted.org/packages/ee/90/b3c01fdec7d2f627b3a6884243ba328c1217ed2d978def5c12dc50d328a3/protobuf-6.33.6-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:e2afbae9b8e1825e3529f88d514754e094278bb95eadc0e199751cdd9a2e82a2", size = 324610 },
+    { url = "https://files.pythonhosted.org/packages/9b/ca/25afc144934014700c52e05103c2421997482d561f3101ff352e1292fb81/protobuf-6.33.6-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:c96c37eec15086b79762ed265d59ab204dabc53056e3443e702d2681f4b39ce3", size = 339381 },
+    { url = "https://files.pythonhosted.org/packages/16/92/d1e32e3e0d894fe00b15ce28ad4944ab692713f2e7f0a99787405e43533a/protobuf-6.33.6-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:e9db7e292e0ab79dd108d7f1a94fe31601ce1ee3f7b79e0692043423020b0593", size = 323436 },
+    { url = "https://files.pythonhosted.org/packages/c4/72/02445137af02769918a93807b2b7890047c32bfb9f90371cbc12688819eb/protobuf-6.33.6-py3-none-any.whl", hash = "sha256:77179e006c476e69bf8e8ce866640091ec42e1beb80b213c3900006ecfba6901", size = 170656 },
 ]
 
 [[package]]
@@ -2214,6 +2313,9 @@ wheels = [
 [package.optional-dependencies]
 openai = [
     { name = "openai" },
+]
+otel = [
+    { name = "opentelemetry-exporter-otlp-proto-http" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Add simple Strands logging and optional Langfuse setup without introducing a larger observability abstraction. The runtime now attaches stable session metadata to traces so multi-turn chats can be filtered by conversation/session ID in Langfuse.

## Changes

- Added straightforward Python logging configuration in `devops_bot.config`, set the `strands` logger to `INFO`, and initialized the Langfuse client only when `LANGFUSE_ENABLED=true`.
- Added `langfuse` and the Strands `otel` extra, documented the related env vars in `.env.example`, and added a short README note for local setup.
- Flushed the Langfuse client on CLI shutdown so short-lived runs export traces reliably.
- Passed `session.id` and `gen_ai.conversation.id` trace attributes into Strands agent construction and generated a session ID in the orchestrator when a caller does not provide one.
- Extended the existing factory and orchestrator tests to cover trace attributes and fallback session ID creation.
- Included the existing `AGENTS.md` guidance update in the branch diff so the reviewer sees the full workspace scope.

## Validation

- [x] `uv run pre-commit run --all-files`
- [x] `uv run mypy`
- [x] `uv run pytest --subprocess-vcr=record`

## Infra Notes

- Deployment, rollout, or operator follow-up: No deployment step; set `LANGFUSE_ENABLED=true` plus Langfuse endpoint and keys in `.env` to emit traces.
- Secrets, credentials, or permissions touched: Added optional `LANGFUSE_BASE_URL`, `LANGFUSE_PUBLIC_KEY`, and `LANGFUSE_SECRET_KEY` configuration. No secret values are committed.
- Ansible, CI, or agent behavior impact: Agent runs now emit standard Python logs and add stable session metadata to Strands traces; this changes observability only, not playbook or Kubernetes execution behavior.

## Risks

- Known tradeoffs: Langfuse still shows one top-level trace per agent invocation; the improvement is correlation via shared session/conversation attributes rather than collapsing multiple messages into one trace.
- Follow-up work: If reviewers want richer Langfuse grouping in the UI, we may need a later pass on naming or additional trace metadata after observing real usage.
