### PR TITLE
[codex] Introduce Homelab Operator branding and CLI aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Homelab Operator is an agentic operations runtime for a Turing Pi homelab.
 
-The repository and compatibility command names remain `devops-agent` for now. The product/display name is `Homelab Operator`.
+The repository name remains unchanged. The preferred CLI names are now `homelab-operator`, `homelab-operator-chat`, and `homelab-operator-tui`; the existing `devops-agent` command names remain available as compatibility aliases.
 
 See `AGENTS.md` for repo-specific guidance on remote tooling, testing expectations, and PR writeups.
 
@@ -80,10 +80,10 @@ Langfuse tracing is optional. Set `LANGFUSE_ENABLED=true` and provide `LANGFUSE_
 ### Example
 
 ```bash
-uv run devops-agent "create a hello world playbook for local nodes"
-uv run devops-agent "Install a k3s cluster with a single control plane on the control node and all cluster nodes joining as workers."
-uv run devops-agent "Install Helm"
-uv run devops-agent "deploy nginx to Kubernetes with Helm"
+uv run homelab-operator "create a hello world playbook for local nodes"
+uv run homelab-operator "Install a k3s cluster with a single control plane on the control node and all cluster nodes joining as workers."
+uv run homelab-operator "Install Helm"
+uv run homelab-operator "deploy nginx to Kubernetes with Helm"
 ```
 
 The generated review includes the proposed filename, metadata header fields, and the full YAML before asking for approval.
@@ -153,7 +153,7 @@ Each CLI invocation creates a new Strands session unless you explicitly reuse `-
 Pass `--session-id` to choose the Strands session ID explicitly:
 
 ```bash
-uv run devops-agent --session-id support-session "create a hello world playbook for local nodes"
+uv run homelab-operator --session-id support-session "create a hello world playbook for local nodes"
 ```
 
 When `--session-id` is set, the JSONL record uses that stable `session_id` and each turn still gets its own `run_id`; the Strands session objects use the CLI-provided session ID.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# Devops Agent
+# Homelab Operator
 
-Figuring out agentic DevOps tooling with a Turing Pi cluster.
+Homelab Operator is an agentic operations runtime for a Turing Pi homelab.
+
+The repository and compatibility command names remain `devops-agent` for now. The product/display name is `Homelab Operator`.
 
 See `AGENTS.md` for repo-specific guidance on remote tooling, testing expectations, and PR writeups.
 
@@ -51,7 +53,7 @@ Generated playbooks support these inventory targets:
 - `cluster` for remote playbooks over SSH
 - `both` for playbooks that include work on both host groups
 
-The agent now generates an Ansible playbook from a natural-language prompt, drafts metadata for the playbook header, shows a structured review, and asks for explicit yes/no approval before creating any file in `ansible/playbooks/`.
+Homelab Operator now generates an Ansible playbook from a natural-language prompt, drafts metadata for the playbook header, shows a structured review, and asks for explicit yes/no approval before creating any file in `ansible/playbooks/`.
 
 ### Draft metadata
 

--- a/devops_bot/chat.py
+++ b/devops_bot/chat.py
@@ -6,7 +6,7 @@ from .approval import ApprovalRequest
 from .workflow import AgentWorkflow, InteractiveAdapter, WorkflowEvent
 
 BANNER = """\
-devops-agent chat
+Homelab Operator chat
   /reset  start a new session (clears conversation history)
   /exit   quit  (also Ctrl-D)
 """

--- a/devops_bot/main.py
+++ b/devops_bot/main.py
@@ -25,7 +25,7 @@ from .workflow import (
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description="Dev Ops Agent.")
+    parser = argparse.ArgumentParser(description="Homelab Operator.")
     parser.add_argument("prompt", help="Natural-language prompt.")
     parser.add_argument("--session-id", help="Specify the Strands session ID for this run.")
     args = parser.parse_args()

--- a/devops_bot/tui.py
+++ b/devops_bot/tui.py
@@ -226,7 +226,7 @@ class DevopsAgentApp(App[None]):
             id="prompt-input",
             soft_wrap=True,
             compact=True,
-            placeholder="Ask the devops agent...",
+            placeholder="Ask Homelab Operator...",
         )
         yield Footer()
 

--- a/justfile
+++ b/justfile
@@ -16,7 +16,7 @@ install-pre-commit:
 
 # Run the agent.
 run:
-    uv run devops-agent
+    uv run homelab-operator
 
 # Run lint checks.
 lint:
@@ -53,7 +53,11 @@ shell:
 
 # Run the CLI.
 cli:
-    uv run devops-agent --help
+    uv run homelab-operator --help
+
+# Run the TUI.
+tui:
+    uv run homelab-operator-tui
 
 # Run Django management commands.
 django-manage *args:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "devops-agent"
 version = "0.1.0"
-description = "Add your description here"
+description = "Homelab Operator for agentic infrastructure and cluster workflows."
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,9 @@ dependencies = [
 devops-agent = "devops_bot.main:main"
 devops-agent-chat = "devops_bot.chat:main"
 devops-agent-tui = "devops_bot.tui:main"
+homelab-operator = "devops_bot.main:main"
+homelab-operator-chat = "devops_bot.chat:main"
+homelab-operator-tui = "devops_bot.tui:main"
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
## Summary

Rename the product-facing identity from Devops Agent to Homelab Operator while keeping the repository name and `devops_bot` package layout unchanged. Add preferred `homelab-operator` CLI aliases so local workflows can adopt the new name without breaking existing `devops-agent` entrypoints.

## Changes

- Updated user-facing branding in the README, CLI help text, chat banner, and TUI placeholder copy.
- Added `homelab-operator`, `homelab-operator-chat`, and `homelab-operator-tui` script aliases alongside the existing `devops-agent` commands.
- Updated the `justfile` and README examples to prefer the new CLI names, including a dedicated `just tui` recipe.

## Validation

- [x] `uv run pre-commit run --all-files`
- [x] `uv run mypy`
- [x] `uv run pytest --subprocess-vcr=record`

## Infra Notes

- Deployment, rollout, or operator follow-up: update any local docs or shell aliases that should prefer `homelab-operator` over `devops-agent`.
- Secrets, credentials, or permissions touched: none.
- Ansible, CI, or agent behavior impact: no remote automation behavior changed; this PR only updates branding, local command aliases, and the default `just` entrypoints.

## Risks

- Known tradeoffs: the repo name, package name, and legacy `devops-agent` commands remain in place, so the naming surface is intentionally mixed during the transition.
- Follow-up work: optionally add broader docs cleanup or eventually rename the Python package if we want a full internal identity change.
